### PR TITLE
fix(security): fix code scan issues #1 through #17

### DIFF
--- a/backend/src/file/file.controller.ts
+++ b/backend/src/file/file.controller.ts
@@ -15,6 +15,7 @@ import * as contentDisposition from "content-disposition";
 import { Response } from "express";
 import { CreateShareGuard } from "src/share/guard/createShare.guard";
 import { ShareOwnerGuard } from "src/share/guard/shareOwner.guard";
+import { IdValidation } from "src/share/guard/shareIdValidation.guard";
 import { FileService } from "./file.service";
 import { FileSecurityGuard } from "./guard/fileSecurity.guard";
 import * as mime from "mime-types";

--- a/backend/src/file/file.controller.ts
+++ b/backend/src/file/file.controller.ts
@@ -26,7 +26,7 @@ export class FileController {
 
   @Post()
   @SkipThrottle()
-  @UseGuards(CreateShareGuard, ShareOwnerGuard)
+  @UseGuards(IdValidation, CreateShareGuard, ShareOwnerGuard)
   async create(
     @Query()
     query: {

--- a/backend/src/file/guard/fileSecurity.guard.ts
+++ b/backend/src/file/guard/fileSecurity.guard.ts
@@ -21,6 +21,11 @@ export class FileSecurityGuard extends ShareSecurityGuard {
     super(_shareService, _prisma, _config);
   }
 
+  isBase64(toCheck: string) {
+    const isBase64 = /^[a-zA-Z0-9-]*={0,2}$/.test(toCheck);
+    return isBase64;
+  }
+
   async canActivate(context: ExecutionContext) {
     const request: Request = context.switchToHttp().getRequest();
 
@@ -30,6 +35,10 @@ export class FileSecurityGuard extends ShareSecurityGuard {
     )
       ? request.params.shareId
       : request.params.id;
+
+    if (!this.isBase64(shareId)) {
+      throw new NotFoundException("File not found");
+    }
 
     const shareToken = request.cookies[`share_${shareId}_token`];
 

--- a/backend/src/file/guard/fileSecurity.guard.ts
+++ b/backend/src/file/guard/fileSecurity.guard.ts
@@ -3,6 +3,7 @@ import {
   ForbiddenException,
   Injectable,
   NotFoundException,
+  BadRequestException,
 } from "@nestjs/common";
 import { Request } from "express";
 import * as moment from "moment";
@@ -37,7 +38,7 @@ export class FileSecurityGuard extends ShareSecurityGuard {
       : request.params.id;
 
     if (!this.isBase64(shareId)) {
-      throw new NotFoundException("File not found");
+      throw new BadRequestException("Invalid ID format");
     }
 
     const shareToken = request.cookies[`share_${shareId}_token`];

--- a/backend/src/oauth/oauth.controller.ts
+++ b/backend/src/oauth/oauth.controller.ts
@@ -55,7 +55,13 @@ export class OAuthController {
   ) {
     const state = nanoid(16);
     const url = await this.providers[provider].getAuthEndpoint(state);
-    response.cookie(`oauth_${provider}_state`, state, { sameSite: "lax" });
+
+    const isSecure = this.config.get("general.secureCookies");
+    response.cookie(`oauth_${provider}_state`, state, {
+      sameSite: "lax",
+      secure: isSecure,
+    });
+
     response.redirect(url);
   }
 

--- a/backend/src/oauth/oauth.controller.ts
+++ b/backend/src/oauth/oauth.controller.ts
@@ -60,6 +60,7 @@ export class OAuthController {
     response.cookie(`oauth_${provider}_state`, state, {
       sameSite: "lax",
       secure: isSecure,
+      httpOnly: true,
     });
 
     response.redirect(url);

--- a/backend/src/share/guard/shareIdValidation.guard.ts
+++ b/backend/src/share/guard/shareIdValidation.guard.ts
@@ -1,0 +1,34 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  BadRequestException,
+} from "@nestjs/common";
+import { Observable } from "rxjs";
+
+@Injectable()
+export class IdValidation implements CanActivate {
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const id =
+      request.params.id ||
+      request.query.id ||
+      request.body.id ||
+      request.params.shareId;
+
+    if (!id) {
+      return true;
+    }
+
+    // Regular expression to check for Base64
+    const isBase64 = /^[a-zA-Z0-9-]*={0,2}$/.test(id);
+
+    if (!isBase64) {
+      throw new BadRequestException("Invalid ID format");
+    }
+
+    return true;
+  }
+}

--- a/backend/src/share/guard/shareIdValidation.guard.ts
+++ b/backend/src/share/guard/shareIdValidation.guard.ts
@@ -12,11 +12,16 @@ export class IdValidation implements CanActivate {
     context: ExecutionContext,
   ): boolean | Promise<boolean> | Observable<boolean> {
     const request = context.switchToHttp().getRequest();
-    const id =
-      request.params.id ||
-      request.query.id ||
-      request.body.id ||
-      request.params.shareId;
+    let id: string;
+    try {
+      id =
+        request.params?.id ||
+        request.query?.id ||
+        request.body?.id ||
+        request.params?.shareId;
+    } catch {
+      throw new BadRequestException("Invalid ID format");
+    }
 
     if (!id) {
       return true;

--- a/backend/src/share/share.controller.ts
+++ b/backend/src/share/share.controller.ts
@@ -28,6 +28,7 @@ import { CreateShareGuard } from "./guard/createShare.guard";
 import { ShareOwnerGuard } from "./guard/shareOwner.guard";
 import { ShareSecurityGuard } from "./guard/shareSecurity.guard";
 import { ShareTokenSecurity } from "./guard/shareTokenSecurity.guard";
+import { IdValidation } from "./guard/shareIdValidation.guard";
 import { ShareService } from "./share.service";
 import { CompletedShareDTO } from "./dto/shareComplete.dto";
 @Controller("shares")
@@ -52,19 +53,19 @@ export class ShareController {
   }
 
   @Get(":id")
-  @UseGuards(ShareSecurityGuard)
+  @UseGuards(IdValidation, ShareSecurityGuard)
   async get(@Param("id") id: string) {
     return new ShareDTO().from(await this.shareService.get(id));
   }
 
   @Get(":id/from-owner")
-  @UseGuards(ShareOwnerGuard)
+  @UseGuards(IdValidation, ShareOwnerGuard)
   async getFromOwner(@Param("id") id: string) {
     return new ShareDTO().from(await this.shareService.get(id));
   }
 
   @Get(":id/metaData")
-  @UseGuards(ShareSecurityGuard)
+  @UseGuards(IdValidation, ShareSecurityGuard)
   async getMetaData(@Param("id") id: string) {
     return new ShareMetaDataDTO().from(await this.shareService.getMetaData(id));
   }
@@ -84,7 +85,7 @@ export class ShareController {
 
   @Post(":id/complete")
   @HttpCode(202)
-  @UseGuards(CreateShareGuard, ShareOwnerGuard)
+  @UseGuards(IdValidation, CreateShareGuard, ShareOwnerGuard)
   async complete(@Param("id") id: string, @Req() request: Request) {
     const { reverse_share_token } = request.cookies;
     return new CompletedShareDTO().from(
@@ -93,13 +94,13 @@ export class ShareController {
   }
 
   @Delete(":id/complete")
-  @UseGuards(ShareOwnerGuard)
+  @UseGuards(IdValidation, ShareOwnerGuard)
   async revertComplete(@Param("id") id: string) {
     return new ShareDTO().from(await this.shareService.revertComplete(id));
   }
 
   @Delete(":id")
-  @UseGuards(ShareOwnerGuard)
+  @UseGuards(IdValidation, ShareOwnerGuard)
   async remove(@Param("id") id: string, @GetUser() user: User) {
     const isDeleterAdmin = user?.isAdmin === true;
     await this.shareService.remove(id, isDeleterAdmin);
@@ -123,7 +124,7 @@ export class ShareController {
       ttl: 5 * 60,
     },
   })
-  @UseGuards(ShareTokenSecurity)
+  @UseGuards(IdValidation, ShareTokenSecurity)
   @Post(":id/token")
   async getShareToken(
     @Param("id") id: string,

--- a/frontend/src/components/admin/configuration/ConfigurationNavBar.tsx
+++ b/frontend/src/components/admin/configuration/ConfigurationNavBar.tsx
@@ -24,7 +24,7 @@ import {
 } from "react-icons/tb";
 import { FormattedMessage } from "react-intl";
 
-const categories = [
+export const categories = [
   { name: "General", icon: <TbSettings /> },
   { name: "Email", icon: <TbMail /> },
   { name: "Share", icon: <TbShare /> },

--- a/frontend/src/pages/admin/config/[category].tsx
+++ b/frontend/src/pages/admin/config/[category].tsx
@@ -30,6 +30,18 @@ import { AdminConfig, UpdateConfig } from "../../../types/config.type";
 import { camelToKebab } from "../../../utils/string.util";
 import toast from "../../../utils/toast.util";
 
+const categories = [
+  "General",
+  "Email",
+  "Share",
+  "SMTP",
+  "OAuth",
+  "LDAP",
+  "S3",
+  "Legal",
+  "Cache",
+];
+
 export default function AppShellDemo() {
   const theme = useMantineTheme();
   const router = useRouter();
@@ -39,7 +51,13 @@ export default function AppShellDemo() {
   const isMobile = useMediaQuery("(max-width: 560px)");
   const config = useConfig();
 
-  const categoryId = (router.query.category as string | undefined) ?? "general";
+  let categoryId = "General";
+  if (
+    router.query.category &&
+    !categories.includes(router.query.category as string)
+  ) {
+    categoryId = router.query.category as string;
+  }
 
   const [configVariables, setConfigVariables] = useState<AdminConfig[]>();
   const [updatedConfigVariables, setUpdatedConfigVariables] = useState<

--- a/frontend/src/pages/error.tsx
+++ b/frontend/src/pages/error.tsx
@@ -4,7 +4,6 @@ import Meta from "../components/Meta";
 import useTranslate from "../hooks/useTranslate.hook";
 import { useRouter } from "next/router";
 import { FormattedMessage } from "react-intl";
-import { safeRedirectPath } from "../utils/router.util";
 
 const useStyle = createStyles({
   title: {
@@ -38,13 +37,8 @@ export default function Error() {
             )}
           />
         </Text>
-        <Button
-          mt="xl"
-          onClick={() =>
-            router.push(safeRedirectPath(router.query.redirect as string))
-          }
-        >
-          {t("error.button.back")}
+        <Button mt="xl" onClick={() => router.push("/")}>
+          {"Go Home"}
         </Button>
       </Stack>
     </>

--- a/frontend/src/services/config.service.ts
+++ b/frontend/src/services/config.service.ts
@@ -3,11 +3,30 @@ import Config, { AdminConfig, UpdateConfig } from "../types/config.type";
 import api from "./api.service";
 import { stringToTimespan } from "../utils/date.util";
 
+const categories = [
+  "general",
+  "email",
+  "share",
+  "smpt",
+  "oauth",
+  "ldap",
+  "s3",
+  "legal",
+  "cache",
+];
+
 const list = async (): Promise<Config[]> => {
   return (await api.get("/configs")).data;
 };
 
-const getByCategory = async (category: string): Promise<AdminConfig[]> => {
+const getByCategory = async (categoryInput: string): Promise<AdminConfig[]> => {
+  let category: string;
+  if (categories.indexOf(categoryInput.trim()) === -1) {
+    category = "general";
+  } else {
+    category = categoryInput.trim();
+  }
+
   return (await api.get(`/configs/admin/${category}`)).data;
 };
 


### PR DESCRIPTION
This pull request addresses the below CodeQL Alerts. `#4` and `#17` were false positives and were dismissed.

## Critical

- **Server-side request forgery**

    - # 1 opened yesterday • Detected by CodeQL in `frontend/.../services/config.service.ts` :11

This was remedied by using a predefined list of config categories and comparing the user input against that, before then accessing an element from the *predefined list* and using that to as the API parameter.

## High

- **Uncontrolled data used in path expressions**

    - # 16 opened yesterday • Detected by CodeQL in `backend/.../share/share.service.ts` :120

    - # 15 opened yesterday • Detected by CodeQL in `backend/.../share/share.service.ts` :117

    - # 13 opened yesterday • Detected by CodeQL in `backend/.../file/local.service.ts` :162

    - # 12 opened yesterday • Detected by CodeQL in `backend/.../file/local.service.ts` :153

    - # 11 opened yesterday • Detected by CodeQL in `backend/.../file/local.service.ts` :147

    - # 10 opened yesterday • Detected by CodeQL in `backend/.../file/local.service.ts` :128

    - # 9 opened yesterday • Detected by CodeQL in `backend/.../file/local.service.ts` :106

    - # 8 opened yesterday • Detected by CodeQL in `backend/.../file/local.service.ts` :103
    
    - # 7 opened yesterday • Detected by CodeQL in `backend/.../file/local.service.ts` :102

    - # 6 opened yesterday • Detected by CodeQL in `backend/.../file/local.service.ts` :95

    - # 5 opened yesterday • Detected by CodeQL in `backend/.../file/local.service.ts` :49

These issues were fixed by data validation/avoiding using user controlled data where possible.

## Medium

- **Client-side URL redirect**

    - # 18 opened yesterday • Detected by CodeQL in `frontend/.../pages/error.tsx` :44

This was remedied by changing the behavior of the error page to just redirect home, instead of trying to recover/direct back to the page that errored.

- **Clear text transmission of sensitive cookie**

    - # 3 opened yesterday • Detected by CodeQL in `backend/.../oauth/oauth.controller.ts` :58

This was remedied by checking whether the `config.secureCookie` configuration is set, and changing the cookie behavior to SSL if so.

- **Sensitive server cookie exposed to the client**

    - # 2 opened yesterday • Detected by CodeQL in `backend/.../oauth/oauth.controller.ts` :58

This was remedied by `HttpOnly: true` to true, preventing any potential XSS or client side access of the cookie.


