### PR TITLE
doc(README): Documentation link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The website is now listening on `http://localhost:3000`.
 
 ## Documentation
 
-For more installation options and advanced configurations, please refer to the [documentation](https://smp46.github.io/pingvin-share).
+For more installation options and advanced configurations, please refer to the [documentation](https://smp46.github.io/pingvin-share-x/).
 
 ## Contributing
 


### PR DESCRIPTION
Fixes a small typo in the link to project documentation.