### PR TITLE
fix(otp): allow older secrets for compatibility

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,7 +20,6 @@
         "@nestjs/schedule": "^5.0.1",
         "@nestjs/swagger": "^11.1.3",
         "@nestjs/throttler": "^6.4.0",
-        "@otplib/v12-adapter": "^13.3.0",
         "@prisma/client": "^6.6.0",
         "@types/jmespath": "^0.15.2",
         "archiver": "^7.0.1",
@@ -3339,21 +3338,6 @@
       "license": "MIT",
       "dependencies": {
         "@otplib/core": "13.3.0"
-      }
-    },
-    "node_modules/@otplib/v12-adapter": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@otplib/v12-adapter/-/v12-adapter-13.3.0.tgz",
-      "integrity": "sha512-xPP6W1ejGjWSwLWmFAamGCOrTyteKMt1zl1gmMoYTl/xypNxuxzKoMRTmSzg/M5xT+S5GKv8kQfu9LeWo2I/TA==",
-      "license": "MIT",
-      "dependencies": {
-        "@otplib/core": "13.3.0",
-        "@otplib/hotp": "13.3.0",
-        "@otplib/plugin-base32-scure": "13.3.0",
-        "@otplib/plugin-crypto-noble": "13.3.0",
-        "@otplib/totp": "13.3.0",
-        "@otplib/uri": "13.3.0",
-        "@scure/base": "^2.0.0"
       }
     },
     "node_modules/@phc/format": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,6 @@
     "@nestjs/schedule": "^5.0.1",
     "@nestjs/swagger": "^11.1.3",
     "@nestjs/throttler": "^6.4.0",
-    "@otplib/v12-adapter": "^13.3.0",
     "@prisma/client": "^6.6.0",
     "@types/jmespath": "^0.15.2",
     "archiver": "^7.0.1",


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Tests
[ ] Other
```

## What's new?
Previous update `v1.14.0` bumped otplib from `v12.0.1` to `v13.3.0`, the update had breaking changes so the `otplib/v12-adapter` was used. The adapter did not account for the legacy TOTP secrets used by otplib's `v12.0.1`. Nor did the adapter support overriding the guardrails to allow the use of legacy secrets.

This update migrates the `authTotp` service to the new otplib `v13.3.0` functions *and* applies the custom guardrails which allow TOTP secrets created before Pingvin `1.14.0` to continue working.

## How has it been tested?
- Enabled TOTP before updating to `v1.14.0`, updated Pingvin, logged in successfully with TOTP. (Specifically testing the bug in #23)
- Removed TOTP, logged in successfully.
- Re-added TOTP, verified initial setup behaves as expected, tested login.

Closes #23 
