### PR TITLE
fix(upload): don't listen for paste when modals open

### DIFF
--- a/frontend/src/pages/upload/index.tsx
+++ b/frontend/src/pages/upload/index.tsx
@@ -20,8 +20,6 @@ import { CreateShare, Share } from "../../types/share.type";
 import toast from "../../utils/toast.util";
 import { useRouter } from "next/router";
 
-import { byteToHumanSizeString } from "../../utils/fileSize.util";
-
 const promiseLimit = pLimit(3);
 let errorToastShown = false;
 let createdShare: Share;
@@ -167,6 +165,10 @@ const Upload = ({
 
   useEffect(() => {
     const handlePaste = (e: ClipboardEvent) => {
+      if (modals.modals.length > 0) {
+        return;
+      }
+
       const clipboardData = e.clipboardData;
 
       if (!clipboardData) {
@@ -206,7 +208,7 @@ const Upload = ({
     return () => {
       window.removeEventListener("paste", handlePaste);
     };
-  }, [autoOpenCreateUploadModal]);
+  }, [autoOpenCreateUploadModal, modals.modals.length]);
 
   useEffect(() => {
     // Check if there are any files that failed to upload


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other


## What's new?
The last update introduced a bug, wherein the `Paste` listener on the `/upload` page wouldn't stop listening for paste events when a modal was opened. This led to anything that's posted in the `Share` modal (inc. passwords, name & descriptions) to be also attached to the share as a file.

## How has it been tested?
Tested pasting with and without modal open, behavior is now consistent and expected.

Closes #39 
