### PR TITLE
fix(shares): appUrl not being used correctly

### DIFF
--- a/frontend/src/components/account/showReverseShareLinkModal.tsx
+++ b/frontend/src/components/account/showReverseShareLinkModal.tsx
@@ -9,7 +9,7 @@ const showReverseShareLinkModal = (
   defaultAppUrl: string,
 ) => {
   const t = translateOutsideContext();
-  const link = `${appUrl !== "" ? defaultAppUrl : window.location.origin}/upload/${reverseShareToken}`;
+  const link = `${appUrl !== defaultAppUrl ? appUrl : window.location.origin}/upload/${reverseShareToken}`;
   return modals.openModal({
     title: t("account.reverseShares.modal.reverse-share-link"),
     children: (

--- a/frontend/src/components/account/showShareInformationsModal.tsx
+++ b/frontend/src/components/account/showShareInformationsModal.tsx
@@ -48,7 +48,7 @@ const Body = ({
     setShowQR(!showQR);
   };
 
-  const link = `${appUrl !== "" ? defaultAppUrl : window.location.origin}/s/${share.id}`;
+  const link = `${appUrl !== defaultAppUrl ? appUrl : window.location.origin}/s/${share.id}`;
 
   const formattedShareSize = byteToHumanSizeString(share.size);
   const formattedMaxShareSize = byteToHumanSizeString(maxShareSize);


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other


## What's new?
- Logic error found on both the reverseShareLinkModal and shareInformationModal, where share urls weren't using the updated appUrl correctly.

## How has it been tested?
- Updated appUrl and tested before and after code changes. Now they correctly and consistently display the same share url.

Closes #42 
