### PR TITLE
feat(redis): redis connection check button

### DIFF
--- a/backend/src/config/config.controller.ts
+++ b/backend/src/config/config.controller.ts
@@ -3,6 +3,8 @@ import {
   Controller,
   FileTypeValidator,
   Get,
+  GatewayTimeoutException,
+  InternalServerErrorException,
   Param,
   ParseFilePipe,
   Patch,
@@ -13,6 +15,7 @@ import {
 } from "@nestjs/common";
 import { FileInterceptor } from "@nestjs/platform-express";
 import { SkipThrottle } from "@nestjs/throttler";
+import { createKeyv } from "@keyv/redis";
 import { AdministratorGuard } from "src/auth/guard/isAdmin.guard";
 import { JwtGuard } from "src/auth/guard/jwt.guard";
 import { EmailService } from "src/email/email.service";
@@ -57,6 +60,73 @@ export class ConfigController {
   @UseGuards(JwtGuard, AdministratorGuard)
   async testEmail(@Body() { email }: TestEmailDTO) {
     await this.emailService.sendTestMail(email);
+  }
+
+  @Post("admin/testRedis")
+  @UseGuards(JwtGuard, AdministratorGuard)
+  async testRedis() {
+    const redisUrl = this.configService.get("cache.redis-url");
+    const enabled = this.configService.get("cache.redis-enabled");
+
+    if (!redisUrl) {
+      throw new InternalServerErrorException("Redis URL is not set");
+    }
+
+    const withTimeout = async <T>(
+      promise: Promise<T>,
+      timeoutMs: number,
+    ): Promise<T> => {
+      let timeout: NodeJS.Timeout | undefined;
+      try {
+        return await Promise.race([
+          promise,
+          new Promise<T>((_, reject) => {
+            timeout = setTimeout(
+              () => reject(new GatewayTimeoutException("Redis timed out")),
+              timeoutMs,
+            );
+          }),
+        ]);
+      } finally {
+        if (timeout) clearTimeout(timeout);
+      }
+    };
+
+    const keyv = createKeyv(
+      {
+        url: redisUrl,
+        socket: {
+          connectTimeout: 3000,
+          reconnectStrategy: () => new Error("Redis connection failed"),
+        },
+      } as any,
+      { namespace: "pingvin" },
+    );
+    const testKey = `connection-test:${Date.now()}`;
+
+    try {
+      await withTimeout(keyv.set(testKey, "ok", 5000), 5000);
+      const value = await withTimeout(keyv.get(testKey), 5000);
+      if (value !== "ok") {
+        throw new Error("Unexpected response from Redis");
+      }
+
+      return { ok: true, enabled };
+    } catch (e: any) {
+      if (e instanceof GatewayTimeoutException) throw e;
+      const message =
+        typeof e?.message === "string"
+          ? `${e?.name ? `${e.name}: ` : ""}${e.message}`
+          : "Redis error";
+      throw new InternalServerErrorException(message);
+    } finally {
+      const store: any = (keyv as any).store;
+      try {
+        await store?.client?.quit?.();
+      } catch {
+        // ignore cleanup errors
+      }
+    }
   }
 
   @Post("admin/logo")

--- a/frontend/src/components/admin/configuration/TestRedisButton.tsx
+++ b/frontend/src/components/admin/configuration/TestRedisButton.tsx
@@ -1,0 +1,111 @@
+import { Button, Stack, Text, Textarea } from "@mantine/core";
+import { useModals } from "@mantine/modals";
+import { useState } from "react";
+import { FormattedMessage } from "react-intl";
+import configService from "../../../services/config.service";
+import { getApiErrorMessage } from "../../../utils/error.util";
+import useTranslate from "../../../hooks/useTranslate.hook";
+import toast from "../../../utils/toast.util";
+
+const TestRedisButton = ({
+  configVariablesChanged,
+  saveConfigVariables,
+}: {
+  configVariablesChanged: boolean;
+  saveConfigVariables: () => Promise<void>;
+}) => {
+  const modals = useModals();
+  const t = useTranslate();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const testRedis = async () => {
+    const result = await configService.testRedisConnection();
+    if (!result.enabled) {
+      toast.success(
+        <FormattedMessage id="admin.config.cache.test-redis.success-disabled" />,
+      );
+    } else {
+      toast.success(
+        <FormattedMessage id="admin.config.cache.test-redis.success" />,
+      );
+    }
+  };
+
+  return (
+    <Button
+      loading={isLoading}
+      variant="light"
+      onClick={async () => {
+        if (!configVariablesChanged) {
+          setIsLoading(true);
+          await testRedis()
+            .catch((e) =>
+              modals.openModal({
+                title: (
+                  <FormattedMessage id="admin.config.cache.test-redis.modal.error.title" />
+                ),
+                children: (
+                  <Stack spacing="xs">
+                    <Text size="sm">
+                      <FormattedMessage id="admin.config.cache.test-redis.modal.error.description" />
+                    </Text>
+                    <Textarea
+                      minRows={4}
+                      readOnly
+                      value={getApiErrorMessage(e) ?? t("common.error.unknown")}
+                    />
+                  </Stack>
+                ),
+              }),
+            )
+            .finally(() => setIsLoading(false));
+        } else {
+          modals.openConfirmModal({
+            title: t("admin.config.cache.test-redis.modal.save.title"),
+            children: (
+              <Text size="sm">
+                <FormattedMessage id="admin.config.cache.test-redis.modal.save.description" />
+              </Text>
+            ),
+            labels: {
+              confirm: t("admin.config.cache.test-redis.modal.save.confirm"),
+              cancel: t("common.button.cancel"),
+            },
+            onConfirm: async () => {
+              setIsLoading(true);
+              await saveConfigVariables();
+              await testRedis()
+                .catch((e) =>
+                  modals.openModal({
+                    title: (
+                      <FormattedMessage id="admin.config.cache.test-redis.modal.error.title" />
+                    ),
+                    children: (
+                      <Stack spacing="xs">
+                        <Text size="sm">
+                          <FormattedMessage id="admin.config.cache.test-redis.modal.error.description" />
+                        </Text>
+                        <Textarea
+                          minRows={4}
+                          readOnly
+                          value={
+                            getApiErrorMessage(e) ?? t("common.error.unknown")
+                          }
+                        />
+                      </Stack>
+                    ),
+                  }),
+                )
+                .finally(() => setIsLoading(false));
+            },
+          });
+        }
+      }}
+    >
+      <FormattedMessage id="admin.config.cache.button.test-redis" />
+    </Button>
+  );
+};
+
+export default TestRedisButton;
+

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -485,6 +485,17 @@ export default {
   "admin.config.cache.redis-url": "Redis URL",
   "admin.config.cache.redis-url.description":
     "Url to connect to the Redis instance used for caching.",
+  "admin.config.cache.button.test-redis": "Test Redis connection",
+  "admin.config.cache.test-redis.success": "Connected to Redis successfully",
+  "admin.config.cache.test-redis.success-disabled":
+    "Connected to Redis successfully (Redis caching is currently disabled).",
+  "admin.config.cache.test-redis.modal.error.title": "Failed to connect to Redis",
+  "admin.config.cache.test-redis.modal.error.description":
+    "While connecting to Redis, the following error occurred:",
+  "admin.config.cache.test-redis.modal.save.title": "Save configuration",
+  "admin.config.cache.test-redis.modal.save.description":
+    "To continue you need to save the configuration first. Do you want to save the configuration and test the Redis connection?",
+  "admin.config.cache.test-redis.modal.save.confirm": "Save and test",
   "admin.config.email.enable-share-email-recipients":
     "Enable email recipient sharing",
   "admin.config.email.enable-share-email-recipients.description":

--- a/frontend/src/pages/admin/config/[category].tsx
+++ b/frontend/src/pages/admin/config/[category].tsx
@@ -22,6 +22,7 @@ import ConfigurationHeader from "../../../components/admin/configuration/Configu
 import ConfigurationNavBar from "../../../components/admin/configuration/ConfigurationNavBar";
 import LogoConfigInput from "../../../components/admin/configuration/LogoConfigInput";
 import TestEmailButton from "../../../components/admin/configuration/TestEmailButton";
+import TestRedisButton from "../../../components/admin/configuration/TestRedisButton";
 import CenterLoader from "../../../components/core/CenterLoader";
 import useConfig from "../../../hooks/config.hook";
 import useTranslate from "../../../hooks/useTranslate.hook";
@@ -327,6 +328,12 @@ export default function AppShellDemo() {
               <Group mt="lg" position="right">
                 {categoryId == "smtp" && (
                   <TestEmailButton
+                    configVariablesChanged={updatedConfigVariables.length != 0}
+                    saveConfigVariables={saveConfigVariables}
+                  />
+                )}
+                {categoryId == "cache" && (
+                  <TestRedisButton
                     configVariablesChanged={updatedConfigVariables.length != 0}
                     saveConfigVariables={saveConfigVariables}
                   />

--- a/frontend/src/services/config.service.ts
+++ b/frontend/src/services/config.service.ts
@@ -68,6 +68,13 @@ const sendTestEmail = async (email: string) => {
   await api.post("/configs/admin/testEmail", { email });
 };
 
+const testRedisConnection = async () => {
+  return (await api.post("/configs/admin/testRedis")).data as {
+    ok: boolean;
+    enabled: boolean;
+  };
+};
+
 const isNewReleaseAvailable = async () => {
   const response = (
     await axios.get(
@@ -97,6 +104,7 @@ export default {
   get,
   finishSetup,
   sendTestEmail,
+  testRedisConnection,
   isNewReleaseAvailable,
   changeLogo,
   changeDarkLogo,

--- a/frontend/src/utils/error.util.ts
+++ b/frontend/src/utils/error.util.ts
@@ -1,0 +1,24 @@
+export function getApiErrorMessage(error: any): string | undefined {
+  const data = error?.response?.data;
+
+  const message = data?.message;
+  if (typeof message === "string" && message.trim().length > 0) return message;
+  if (Array.isArray(message)) {
+    const joined = message.filter(Boolean).join("\n");
+    if (joined.trim().length > 0) return joined;
+  }
+
+  const errorField = data?.error;
+  if (typeof errorField === "string" && errorField.trim().length > 0)
+    return errorField;
+
+  if (typeof error?.message === "string" && error.message.trim().length > 0)
+    return error.message;
+
+  try {
+    if (data) return JSON.stringify(data, null, 2);
+  } catch {
+    // ignore
+  }
+  return undefined;
+}

--- a/frontend/src/utils/toast.util.tsx
+++ b/frontend/src/utils/toast.util.tsx
@@ -1,8 +1,13 @@
 import { NotificationProps, showNotification } from "@mantine/notifications";
 import { TbCheck, TbX } from "react-icons/tb";
 import { FormattedMessage } from "react-intl";
+import { getApiErrorMessage } from "./error.util";
+import { ReactNode } from "react";
 
-const error = (message: string, config?: Omit<NotificationProps, "message">) =>
+const error = (
+  message: ReactNode,
+  config?: Omit<NotificationProps, "message">,
+) =>
   showNotification({
     icon: <TbX />,
     color: "red",
@@ -16,10 +21,14 @@ const error = (message: string, config?: Omit<NotificationProps, "message">) =>
   });
 
 const axiosError = (axiosError: any) =>
-  error(axiosError?.response?.data?.message ?? "An unknown error occurred");
+  error(
+    getApiErrorMessage(axiosError) ?? (
+      <FormattedMessage id="common.error.unknown" />
+    ),
+  );
 
 const success = (
-  message: string,
+  message: ReactNode,
   config?: Omit<NotificationProps, "message">,
 ) =>
   showNotification({


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other


## What's new?
- The Administrator can now perform a connection test on the configured Redis server. The test involves inserting a test key into Redis with value `connection-test:${Date.now()}`. On failure it will report the response/cause back to the frontend.

## How has it been tested?
- Tested with a Redis instance running locally in Docker, when correctly configured the test returns immediately.
- When given no/an invalid URL the test times out and returns `Error: The client is closed` in a popup.
- The test ensures that the users entered values are saved (updated server-side) before running.

## Screenshots
New Test Button on Cache config page:
<img width="714" height="524" alt="image" src="https://github.com/user-attachments/assets/72113e1c-d6a6-4bff-943a-5a064b505e23" />

Save Before Testing Popup:
<img width="472" height="202" alt="image" src="https://github.com/user-attachments/assets/e9897a8f-5db0-414c-992d-0206b9234040" />

Test Failure Popup:
<img width="466" height="247" alt="image" src="https://github.com/user-attachments/assets/1e22e36a-ab16-492b-81fd-9c552e06be5f" />


Closes #29 
