### PR TITLE
feat(s3): support for ClamAV scans with S3 Buckets

### DIFF
--- a/backend/src/clamscan/clamscan.service.ts
+++ b/backend/src/clamscan/clamscan.service.ts
@@ -36,13 +36,69 @@ export class ClamScanService {
   async check(shareId: string) {
     const clamScan = await this.ClamScan;
 
-    if (!clamScan) return [];
+    if (!clamScan) {
+      return [];
+    }
 
     const infectedFiles = [];
 
-    const files = fs
-      .readdirSync(`${SHARE_DIRECTORY}/${shareId}`)
-      .filter((file) => file != "archive.zip");
+    const share = await this.prisma.share.findUnique({
+      where: { id: shareId },
+    });
+    const storageProvider = share?.storageProvider || "UNKNOWN";
+
+    if (storageProvider === "S3") {
+      const files = await this.prisma.file.findMany({
+        where: { shareId },
+        select: { id: true, name: true },
+      });
+
+      for (const f of files) {
+        try {
+          const fileObj = await this.fileService.get(shareId, f.id);
+
+          const tmpDir = `${SHARE_DIRECTORY}/${shareId}`;
+          const tmpPath = `${tmpDir}/${f.id}`;
+
+          fs.mkdirSync(tmpDir, { recursive: true });
+
+          // Download S3 object stream to temp local file
+          await new Promise<void>((resolve, reject) => {
+            const writeStream = fs.createWriteStream(tmpPath);
+            (fileObj.file as any).pipe(writeStream);
+            writeStream.on("finish", resolve);
+            writeStream.on("error", reject);
+            (fileObj.file as any).on("error", reject);
+          });
+
+          const { isInfected } = await clamScan
+            .isInfected(tmpPath)
+            .catch(() => ({ isInfected: false }));
+
+          if (isInfected) infectedFiles.push({ id: f.id, name: f.name });
+
+          try {
+            fs.unlinkSync(tmpPath);
+          } catch {}
+        } catch (err: any) {
+          this.logger.warn(
+            `ClamAV scan failed for S3 file ${f.id} in share ${shareId}: ${err?.message || "unknown error"}`,
+          );
+        }
+      }
+
+      return infectedFiles;
+    }
+
+    let files: string[] = [];
+    try {
+      files = fs
+        .readdirSync(`${SHARE_DIRECTORY}/${shareId}`)
+        .filter((file) => file != "archive.zip");
+    } catch (e) {
+      void e;
+      return [];
+    }
 
     for (const fileId of files) {
       const { isInfected } = await clamScan
@@ -68,8 +124,15 @@ export class ClamScanService {
     const infectedFiles = await this.check(shareId);
 
     if (infectedFiles.length > 0) {
-      await this.fileService.deleteAllFiles(shareId);
-      await this.prisma.file.deleteMany({ where: { shareId } });
+      try {
+        await this.fileService.deleteAllFiles(shareId);
+        await this.prisma.file.deleteMany({ where: { shareId } });
+      } catch (err: any) {
+        this.logger.error(
+          `Failed to delete malicious share ${shareId}: ${err?.message || "unknown error"}`,
+        );
+        return;
+      }
 
       const fileNames = infectedFiles.map((file) => file.name).join(", ");
 

--- a/backend/src/file/file.service.ts
+++ b/backend/src/file/file.service.ts
@@ -50,12 +50,20 @@ export class FileService {
   }
 
   async remove(shareId: string, fileId: string) {
-    const storageService = this.getStorageService();
+    const share = await this.prisma.share.findFirst({
+      where: { id: shareId },
+      select: { storageProvider: true },
+    });
+    const storageService = this.getStorageService(share?.storageProvider);
     return storageService.remove(shareId, fileId);
   }
 
   async deleteAllFiles(shareId: string) {
-    const storageService = this.getStorageService();
+    const share = await this.prisma.share.findFirst({
+      where: { id: shareId },
+      select: { id: true, storageProvider: true },
+    });
+    const storageService = this.getStorageService(share?.storageProvider);
     return storageService.deleteAllFiles(shareId);
   }
 

--- a/backend/src/file/s3.service.ts
+++ b/backend/src/file/s3.service.ts
@@ -222,18 +222,42 @@ export class S3FileService {
   async deleteAllFiles(shareId: string) {
     const prefix = `${this.getS3Path()}${shareId}/`;
     const s3Instance = this.getS3Instance();
+    const bucketName = this.config.get("s3.bucketName");
+
+    const fallbackDeleteByDb = async (reason: string) => {
+      void reason;
+
+      const files = await this.prisma.file.findMany({
+        where: { shareId },
+        select: { name: true },
+      });
+
+      for (const f of files) {
+        const key = `${this.getS3Path()}${shareId}/${f.name}`;
+        try {
+          await s3Instance.send(
+            new DeleteObjectCommand({
+              Bucket: bucketName,
+              Key: key,
+            }),
+          );
+        } catch {
+          // ignore per-object failure
+        }
+      }
+    };
 
     try {
       // List all objects under the given prefix
       const listResponse = await s3Instance.send(
         new ListObjectsV2Command({
-          Bucket: this.config.get("s3.bucketName"),
+          Bucket: bucketName,
           Prefix: prefix,
         }),
       );
 
       if (!listResponse.Contents || listResponse.Contents.length === 0) {
-        throw new Error(`No files found for share ${shareId}`);
+        return;
       }
 
       // Extract the keys of the files to be deleted
@@ -244,14 +268,16 @@ export class S3FileService {
       // Delete all files in a single request (up to 1000 objects at once)
       await s3Instance.send(
         new DeleteObjectsCommand({
-          Bucket: this.config.get("s3.bucketName"),
+          Bucket: bucketName,
           Delete: {
             Objects: objectsToDelete,
           },
         }),
       );
     } catch (error) {
-      throw new Error("Could not delete all files from S3");
+      // try deleting by known file names from DB instead.
+      await fallbackDeleteByDb("list_or_bulk_delete_failed");
+      void error;
     }
   }
 
@@ -385,6 +411,8 @@ export class S3FileService {
 
   getS3Path(): string {
     const configS3Path = this.config.get("s3.bucketPath");
-    return configS3Path ? `${configS3Path}/` : "";
+    if (!configS3Path) return "";
+    const normalized = `${configS3Path}`.replace(/^\/+|\/+$/g, "");
+    return normalized ? `${normalized}/` : "";
   }
 }

--- a/backend/src/file/s3.service.ts
+++ b/backend/src/file/s3.service.ts
@@ -225,12 +225,11 @@ export class S3FileService {
     const bucketName = this.config.get("s3.bucketName");
 
     const fallbackDeleteByDb = async (reason: string) => {
-      void reason;
-
       const files = await this.prisma.file.findMany({
         where: { shareId },
         select: { name: true },
       });
+      void reason;
 
       for (const f of files) {
         const key = `${this.getS3Path()}${shareId}/${f.name}`;

--- a/backend/src/jobs/jobs.service.ts
+++ b/backend/src/jobs/jobs.service.ts
@@ -39,11 +39,10 @@ export class JobsService {
     });
 
     for (const expiredShare of expiredShares) {
+      await this.fileService.deleteAllFiles(expiredShare.id);
       await this.prisma.share.delete({
         where: { id: expiredShare.id },
       });
-
-      await this.fileService.deleteAllFiles(expiredShare.id);
     }
 
     if (expiredShares.length > 0) {
@@ -80,11 +79,10 @@ export class JobsService {
     });
 
     for (const unfinishedShare of unfinishedShares) {
+      await this.fileService.deleteAllFiles(unfinishedShare.id);
       await this.prisma.share.delete({
         where: { id: unfinishedShare.id },
       });
-
-      await this.fileService.deleteAllFiles(unfinishedShare.id);
     }
 
     if (unfinishedShares.length > 0) {

--- a/docs/docs/setup/s3.md
+++ b/docs/docs/setup/s3.md
@@ -11,22 +11,22 @@ want to store your files on a S3 bucket, you don't have to. Consider that this f
 
 You can configure your S3 provider and bucket by going to the configuration page in your admin dashboard `/admin/config/s3`.
 
-| Key        | Description                                                                                                                          | Value                                         |
-|:-----------|:-------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------|
-| enabled    | This property enables the storage location on your configured S3 bucket.                                                             | `true`                                        |
-| endpoint   | The host for your S3 bucket. Endpoint formats vary by provider and some may include the bucket name in the FQDN. Ensure this is configured correctly, as an incorrect value may break some features.                                                                                       | `sos-ch-dk-2.exo.io`                                 |
-| region     | This property is the region where the bucket is located.                                                                             | `sos-ch-dk-2`                          |
-| bucketName | This property is the name of your S3 bucket.                                                                                         | `my-bucket`                                   |
-| bucketPath | This property defines the folder where you want to store your files which are uploaded. Hint: Don't put a slash in the start or end. | `my/custom/path` (or leave it empty for root) |
-| key        | This is the access key you need to access to your bucket.                                                                            | `key-asdf`                                    |
-| secret     | This is the secret you need to access to your bucket.                                                                                | `secret-asdf`                                 |
+| Key        | Description                                                                                                                                                                                          | Value                                         |
+| :--------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------- |
+| enabled    | This property enables the storage location on your configured S3 bucket.                                                                                                                             | `true`                                        |
+| endpoint   | The host for your S3 bucket. Endpoint formats vary by provider and some may include the bucket name in the FQDN. Ensure this is configured correctly, as an incorrect value may break some features. | `sos-ch-dk-2.exo.io`                          |
+| region     | This property is the region where the bucket is located.                                                                                                                                             | `sos-ch-dk-2`                                 |
+| bucketName | This property is the name of your S3 bucket.                                                                                                                                                         | `my-bucket`                                   |
+| bucketPath | This property defines the folder where you want to store your files which are uploaded. Hint: Don't put a slash in the start or end.                                                                 | `my/custom/path` (or leave it empty for root) |
+| key        | This is the access key you need to access to your bucket.                                                                                                                                            | `key-asdf`                                    |
+| secret     | This is the secret you need to access to your bucket.                                                                                                                                                | `secret-asdf`                                 |
 
 Don't forget to save the configuration. :)
 
 ## ClamAV
 
-Consider that ClamAV scans are not available at the moment if you store your files in a S3 bucket. 
+When S3 is used in conjunction with ClamAV, the file is first uploaded to the S3 bucket, then downloaded temporarily by the backend server, scanned by ClamAV then removed from the backend and actioned. This can lead to increased scanning times, especially for larger files, due to the additional upload and download steps. If you are experiencing slow scanning times, consider disabling S3 or ClamAV.
 
-## ZIP 
+## ZIP
 
 Creating ZIP archives is not currently supported if you store your files in an S3 bucket.

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -440,7 +440,8 @@ export default {
   "admin.config.appearance.theme-primary-color": "Theme primary color",
   "admin.config.appearance.theme-primary-color.description":
     "Primary color used for buttons, links, and accents. Choose custom to use a color picker override.",
-  "admin.config.appearance.theme-primary-color-override": "Custom primary color",
+  "admin.config.appearance.theme-primary-color-override":
+    "Custom primary color",
   "admin.config.appearance.theme-primary-color-override.description":
     "Hex color override used when theme primary color is set to custom.",
   "admin.config.appearance.theme-font-preset": "Theme font preset",
@@ -471,7 +472,8 @@ export default {
   "admin.config.general.logo.description":
     "Change your logo by uploading a new image. The image must be a PNG and should have the format 1:1.",
   "admin.config.general.logo-dark": "Dark mode logo",
-  "admin.config.general.logo-dark.description": "Upload a separate logo for dark mode. The image must be a PNG and should have the format 1:1.",
+  "admin.config.general.logo-dark.description":
+    "Upload a separate logo for dark mode. The image must be a PNG and should have the format 1:1.",
   "admin.config.general.logo.placeholder": "Pick image",
   "admin.config.cache.ttl": "TTL",
   "admin.config.cache.ttl.description":
@@ -489,7 +491,8 @@ export default {
   "admin.config.cache.test-redis.success": "Connected to Redis successfully",
   "admin.config.cache.test-redis.success-disabled":
     "Connected to Redis successfully (Redis caching is currently disabled).",
-  "admin.config.cache.test-redis.modal.error.title": "Failed to connect to Redis",
+  "admin.config.cache.test-redis.modal.error.title":
+    "Failed to connect to Redis",
   "admin.config.cache.test-redis.modal.error.description":
     "While connecting to Redis, the following error occurred:",
   "admin.config.cache.test-redis.modal.save.title": "Save configuration",
@@ -701,7 +704,7 @@ export default {
   "admin.config.category.s3": "S3",
   "admin.config.s3.enabled": "Enabled",
   "admin.config.s3.enabled.description":
-    "Whether S3 should be used to store the shared files instead of the local file system.",
+    "Whether S3 should be used to store the shared files instead of the local file system. WARNING: If ClamAV is active, files will be temporarily downloaded from S3 to be checked.",
   "admin.config.s3.endpoint": "Endpoint",
   "admin.config.s3.endpoint.description": "The URL of the S3 bucket.",
   "admin.config.s3.region": "Region",


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other


## What's new?
- ClamAV is now supported when a S3 Bucket is configured. Previously, scans were not attempted. Now the file is uploaded to the bucket, fetched by the backend and scanned locally before being actioned (kept or deleted). I was unable to get ClamAV to work with the stream as it was being uploaded, so this was the workaround.

## How has it been tested?
- Tested ClamAV scanning works as expected both with and without a S3 enabled.
- Tested files are actually removed from S3 after a malicious file is found.
- Tested regular uploads without ClamAV enabled.
- Tested manual deletion of files work as expected on S3 and local.
- All testing was done with the EICAR test file
- Documentation has been updated to reflect the change, and warn of extra bandwith required for scans.


Closes #41 
