### PR TITLE
BUGFIX: fix custom color input visible when custom not selected

### DIFF
--- a/frontend/src/pages/admin/config/[category].tsx
+++ b/frontend/src/pages/admin/config/[category].tsx
@@ -103,7 +103,7 @@ export default function AppShellDemo() {
               const updated = updatedConfigVariables.find(
                 (u) => u.key === cv.key,
               );
-              return updated ? { ...cv, value: updated.value } : cv;
+              return updated ? { ...cv, value: String(updated.value) } : cv;
             }),
           );
           setUpdatedConfigVariables([]);

--- a/frontend/src/pages/admin/config/[category].tsx
+++ b/frontend/src/pages/admin/config/[category].tsx
@@ -98,6 +98,14 @@ export default function AppShellDemo() {
       await configService
         .updateMany(updatedConfigVariables)
         .then(() => {
+          setConfigVariables((prev) =>
+            prev?.map((cv) => {
+              const updated = updatedConfigVariables.find(
+                (u) => u.key === cv.key,
+              );
+              return updated ? { ...cv, value: updated.value } : cv;
+            }),
+          );
           setUpdatedConfigVariables([]);
           toast.success(t("admin.config.notify.success"));
         })


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other


## What's fixed?
When a user had previously set a custom primary color (appearance.themePrimaryColor = "custom" + a hex value in appearance.themePrimaryColorOverride), then switched back to a preset color and saved — the custom color input would reappear immediately after saving.

Root cause: After a successful save, setUpdatedConfigVariables([]) cleared the pending changes but the local configVariables state (loaded on page mount) still held the old stale values. The visibility check                                              
  getEffectiveConfigValue("appearance.themePrimaryColor") === "custom" first looks in updatedConfigVariables (now empty), then falls back to configVariables (still showing "custom" from before). This caused the color override input to show again even though "custom" was no longer the active selection.                                                                                                                                                                                                          
                                                            
Fix (frontend/src/pages/admin/config/[category].tsx): After a successful save, update configVariables in-place with the newly saved values before clearing updatedConfigVariables. This ensures the fallback lookup always reflects what is actually stored in the database


## How has it been tested?
Docker image created, scenario tested and see it fixed the issue. 

## Screenshots

N/A
