### PR TITLE
feat(email): make share-recipients fallbacks and date locale configurable

### DIFF
--- a/backend/prisma/seed/config.seed.ts
+++ b/backend/prisma/seed/config.seed.ts
@@ -152,6 +152,22 @@ export const configVariables = {
       defaultValue:
         "Hey!\n\n{creator} ({creatorEmail}) shared some files with you. You can view or download the files with this link: {shareUrl}\n\nThe share will expire {expires}.\n\nNote: {desc}\n\nShared securely with Pingvin Share 🐧",
     },
+    shareRecipientsCreatorFallback: {
+      type: "string",
+      defaultValue: "Someone",
+    },
+    shareRecipientsDescFallback: {
+      type: "string",
+      defaultValue: "No description",
+    },
+    shareRecipientsExpiresNeverFallback: {
+      type: "string",
+      defaultValue: "in: never",
+    },
+    locale: {
+      type: "string",
+      defaultValue: "en",
+    },
     reverseShareSubject: {
       type: "string",
       defaultValue: "Reverse share link used",

--- a/backend/src/email/email.service.ts
+++ b/backend/src/email/email.service.ts
@@ -68,15 +68,24 @@ export class EmailService {
       this.config
         .get("email.shareRecipientsMessage")
         .replaceAll("\\n", "\n")
-        .replaceAll("{creator}", creator?.username ?? "Someone")
+        .replaceAll(
+          "{creator}",
+          creator?.username ??
+            this.config.get("email.shareRecipientsCreatorFallback"),
+        )
         .replaceAll("{creatorEmail}", creator?.email ?? "")
         .replaceAll("{shareUrl}", shareUrl)
-        .replaceAll("{desc}", description ?? "No description")
+        .replaceAll(
+          "{desc}",
+          description ?? this.config.get("email.shareRecipientsDescFallback"),
+        )
         .replaceAll(
           "{expires}",
           moment(expiration).unix() != 0
-            ? moment(expiration).fromNow()
-            : "in: never",
+            ? moment(expiration)
+                .locale(this.config.get("email.locale"))
+                .fromNow()
+            : this.config.get("email.shareRecipientsExpiresNeverFallback"),
         ),
     );
   }

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -509,6 +509,22 @@ export default {
   "admin.config.email.share-recipients-message": "Share recipients message",
   "admin.config.email.share-recipients-message.description":
     "Message which gets sent to the share recipients. Available variables:\n {creator} - The username of the creator of the share\n {creatorEmail} - The email of the creator of the share\n {shareUrl} - The URL of the share\n {desc} - The description of the share\n {expires} - The expiration date of the share\n These variables will be replaced with the actual value.",
+  "admin.config.email.share-recipients-creator-fallback":
+    "Share recipients creator fallback",
+  "admin.config.email.share-recipients-creator-fallback.description":
+    "Text used in place of {creator} when the share creator has no username.",
+  "admin.config.email.share-recipients-desc-fallback":
+    "Share recipients description fallback",
+  "admin.config.email.share-recipients-desc-fallback.description":
+    "Text used in place of {desc} when the share has no description. Set to an empty string to omit the description entirely.",
+  "admin.config.email.share-recipients-expires-never-fallback":
+    "Share recipients no-expiration fallback",
+  "admin.config.email.share-recipients-expires-never-fallback.description":
+    "Text used in place of {expires} when the share never expires.",
+  "admin.config.email.locale":
+    "Email locale",
+  "admin.config.email.locale.description":
+    "Locale used to render relative expiration dates in the share recipients email (for example \"en\", \"de\", \"nl\"). Must be a locale supported by moment.js.",
   "admin.config.email.reverse-share-subject": "Reverse share subject",
   "admin.config.email.reverse-share-subject.description":
     "Subject of the sent email when someone created a share with your reverse share link.",


### PR DESCRIPTION
Closes #64.

### What

Four hardcoded English strings in `sendMailToShareRecipients` are now driven by config keys, so operators running the instance in another language can localize them from the admin UI instead of patching the compiled JS:

| New key | Default | Replaces |
|---------|---------|----------|
| `email.shareRecipientsCreatorFallback` | `Someone` | `?? "Someone"` for `{creator}` |
| `email.shareRecipientsDescFallback` | `No description` | `?? "No description"` for `{desc}` |
| `email.shareRecipientsExpiresNeverFallback` | `in: never` | `"in: never"` for `{expires}` when expiration is unset |
| `email.locale` | `en` | Passed to `moment().locale(...)` so relative dates render in the configured language |

### Backwards compatibility

All defaults are byte-identical to the previous hardcoded literals. Moment ships with all locales preloaded in Node, so `email.locale: "en"` produces the same output as the previous code that omitted the `.locale()` call. Existing instances render identical email bodies until an operator opts in.

### Files changed

- `backend/src/email/email.service.ts` (4 substitutions + locale call)
- `backend/prisma/seed/config.seed.ts` (4 new entries in the existing `email:` block)
- `frontend/src/i18n/translations/en-US.ts` (4 labels + 4 descriptions for the admin UI; other locales will pick up the new keys via the existing Crowdin workflow)

### Out of scope

- No new i18n library or message-bundle pipeline. The existing `email.*Message` keys already let operators write the body in any language; these four additions just close the remaining gaps.
- No changes to `sendMailToReverseShareCreator`, invite, or reset-password flows. They already route everything through configurable templates.

### Verification

- Ran `npx prettier --end-of-line=auto --write` on the three changed files; only `email.service.ts` was reformatted.
- Diff confirmed no behavioral change for instances that keep the seeded defaults.