### PR TITLE
fix(email): fix inconsistent smpt and email behavior

### DIFF
--- a/frontend/src/components/admin/configuration/AdminConfigInput.tsx
+++ b/frontend/src/components/admin/configuration/AdminConfigInput.tsx
@@ -14,7 +14,11 @@ import {
 import { useForm } from "@mantine/form";
 import { TbDeviceLaptop, TbMoon, TbSun } from "react-icons/tb";
 import { FormattedMessage } from "react-intl";
-import { AdminConfig, UpdateConfig } from "../../../types/config.type";
+import {
+  AdminConfig,
+  AdminConfigGroupedByCategory,
+  UpdateConfig,
+} from "../../../types/config.type";
 import { stringToTimespan, timespanToString } from "../../../utils/date.util";
 import FileSizeInput from "../../core/FileSizeInput";
 import TimespanInput from "../../core/TimespanInput";
@@ -24,11 +28,13 @@ const AdminConfigInput = ({
   updateConfigVariable,
   allConfigVariables,
   updatedConfigVariables,
+  optionalConfigVariables,
 }: {
   configVariable: AdminConfig;
   updateConfigVariable: (variable: UpdateConfig) => void;
   allConfigVariables?: AdminConfig[];
   updatedConfigVariables?: UpdateConfig[];
+  optionalConfigVariables?: AdminConfig[];
 }) => {
   const isCustomCssConfig = configVariable.key === "appearance.customCss";
   const isThemePrimaryColorConfig =
@@ -38,6 +44,15 @@ const AdminConfigInput = ({
   const isThemeRadiusConfig = configVariable.key === "appearance.themeRadius";
   const isThemeColorSchemeConfig =
     configVariable.key === "appearance.themeColorScheme";
+  const isEmailShareConfig =
+    configVariable.key === "email.enableShareEmailRecipients";
+  let isSmtpEnabled = false;
+
+  if (isEmailShareConfig) {
+    isSmtpEnabled =
+      optionalConfigVariables?.find((config) => config.key === "smtp.enabled")
+        ?.value === "true";
+  }
 
   const getEffectiveConfigValue = (key: string): string | undefined => {
     const updatedValue = updatedConfigVariables?.find(
@@ -251,7 +266,16 @@ const AdminConfigInput = ({
           w={201}
         />
       )}
-      {configVariable.type == "boolean" && (
+      {configVariable.type == "boolean" && isEmailShareConfig && (
+        <>
+          <Switch
+            disabled={!isSmtpEnabled}
+            {...form.getInputProps("booleanValue", { type: "checkbox" })}
+            onChange={(e) => onValueChange(configVariable, e.target.checked)}
+          />
+        </>
+      )}
+      {configVariable.type == "boolean" && !isEmailShareConfig && (
         <>
           <Switch
             disabled={!configVariable.allowEdit}

--- a/frontend/src/components/upload/modals/showCreateUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCreateUploadModal.tsx
@@ -132,6 +132,7 @@ const CreateUploadModalBody = ({
   const generatedLink = generateShareId(options.shareIdLength);
 
   const [showNotSignedInAlert, setShowNotSignedInAlert] = useState(true);
+  const [emailSearch, setEmailSearch] = useState("");
 
   const validationSchema = yup.object().shape({
     link: yup
@@ -404,6 +405,8 @@ const CreateUploadModalBody = ({
                     creatable
                     id="recipient-emails"
                     inputMode="email"
+                    searchValue={emailSearch}
+                    onSearchChange={setEmailSearch}
                     getCreateLabel={(query) => `+ ${query}`}
                     onCreate={(query) => {
                       if (!query.match(/^\S+@\S+\.\S+$/)) {
@@ -411,33 +414,29 @@ const CreateUploadModalBody = ({
                           "recipients",
                           t("upload.modal.accordion.email.invalid-email"),
                         );
-                      } else {
-                        form.setFieldError("recipients", null);
-                        form.setFieldValue("recipients", [
-                          ...form.values.recipients,
-                          query,
-                        ]);
-                        return query;
+                        return undefined;
                       }
+                      form.setFieldError("recipients", null);
+                      return query;
                     }}
                     {...form.getInputProps("recipients")}
                     onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
-                      // Add email on comma or semicolon
                       if (e.key === "Enter" || e.key === "," || e.key === ";") {
                         e.preventDefault();
-                        const inputValue = (
-                          e.target as HTMLInputElement
-                        ).value.trim();
-                        if (inputValue.match(/^\S+@\S+\.\S+$/)) {
+                        const inputValue = emailSearch.trim();
+                        if (
+                          inputValue.match(/^\S+@\S+\.\S+$/) &&
+                          !form.values.recipients.includes(inputValue)
+                        ) {
                           form.setFieldValue("recipients", [
                             ...form.values.recipients,
                             inputValue,
                           ]);
-                          (e.target as HTMLInputElement).value = "";
                         }
+                        setEmailSearch("");
                       } else if (e.key === " ") {
                         e.preventDefault();
-                        (e.target as HTMLInputElement).value = "";
+                        setEmailSearch("");
                       }
                     }}
                   />

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -507,7 +507,7 @@ export default {
   "admin.config.email.enable-share-email-recipients":
     "Enable email recipient sharing",
   "admin.config.email.enable-share-email-recipients.description":
-    "Whether to allow email sharing with recipients. Only enable this if SMTP is activated.",
+    "Whether to allow email sharing with recipients. This can only be enabled if SMTP is activated.",
   "admin.config.email.share-recipients-subject": "Share recipients subject",
   "admin.config.email.share-recipients-subject.description":
     "Subject of the email which gets sent to the share recipients.",

--- a/frontend/src/pages/admin/config/[category].tsx
+++ b/frontend/src/pages/admin/config/[category].tsx
@@ -65,6 +65,8 @@ export default function AppShellDemo() {
   const [updatedConfigVariables, setUpdatedConfigVariables] = useState<
     UpdateConfig[]
   >([]);
+  const [optionalConfigVariables, setOptionalConfigVariables] =
+    useState<AdminConfig[]>();
 
   const [logo, setLogo] = useState<File | null>(null);
   const [darkLogo, setDarkLogo] = useState<File | null>(null);
@@ -143,6 +145,19 @@ export default function AppShellDemo() {
     configService.getByCategory(categoryId).then((configVariables) => {
       setConfigVariables(configVariables);
     });
+
+    if (categoryId === "email") {
+      configService.getByCategory("smtp").then((smtpConfigVariables) => {
+        const optionalConfigVariables = smtpConfigVariables.filter(
+          (configVariable) => {
+            if (configVariable.key === "smtp.enabled") {
+              return configVariable;
+            }
+          },
+        );
+        setOptionalConfigVariables(optionalConfigVariables);
+      });
+    }
   }, [categoryId]);
 
   return (
@@ -270,6 +285,9 @@ export default function AppShellDemo() {
                                 updateConfigVariable={updateConfigVariable}
                                 allConfigVariables={configVariables}
                                 updatedConfigVariables={updatedConfigVariables}
+                                optionalConfigVariables={
+                                  optionalConfigVariables
+                                }
                               />
                             </Box>
                           </Group>
@@ -325,6 +343,9 @@ export default function AppShellDemo() {
                                 updateConfigVariable={updateConfigVariable}
                                 allConfigVariables={configVariables}
                                 updatedConfigVariables={updatedConfigVariables}
+                                optionalConfigVariables={
+                                  optionalConfigVariables
+                                }
                               />
                             </Box>
                           </Group>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix(es)
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

AI was not used for this PR.

## What's new?
- Pressing enter (or comma, or semi-colon) when adding email recipients to a share no longer duplicates the email address.
- Duplicate emails now can't be entered manually either, the form now checks if the email is already in the form before adding it.
- Email recipient sharing now can't be enabled if SMTP is not also enabled & configured. This prevents the weird behavior of trying to send emails without SMTP. 

## How has it been tested?
- Typing an email then pressing enter or comma or semi-colon, inserts the email into the list without duplicating.
- Duplicate emails disappear after trying to submit. Confirmed that duplicate emails aren't sent after this.
- If SMTP is disabled, the "Enable email recipient sharing" is now greyed out and cannot be toggled. If SMTP is enabled the toggle behaves as expected.

Closes #71, closes #72 
