### PR TITLE
Fix direct file share link

### DIFF
--- a/frontend/src/components/share/FileList.tsx
+++ b/frontend/src/components/share/FileList.tsx
@@ -67,7 +67,7 @@ const FileList = ({
   };
 
   const copyFileLink = (file: FileMetaData) => {
-    const link = `${config.get("general.appUrl") !== config.get("general.appUrl", true) ? config.get("appUrl") : window.location.origin}/api/shares/${
+    const link = `${config.get("general.appUrl") !== config.get("general.appUrl", true) ? config.get("general.appUrl") : window.location.origin}/api/shares/${
       share.id
     }/files/${file.id}`;
 


### PR DESCRIPTION
The direct fileshare link was not working because of appUrl not being a config param. it is general.appUrl. Fixes #74

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

If you answer Yes and you have used AI in this submission disclose it here.
If you answer No and this PR that appears to be fully or largely AI-generated, it will be closed by the maintainers.
I used Codex to find the bug. Then tested it running local docker build. 
## What's new?

## How has it been tested?

## Screenshots

N/A
