### PR TITLE
Fix older shares don't get deleted when adding stuff during cleanup cron running

### DIFF
--- a/backend/prisma/migrations/20260523120000_add_share_updated_at/migration.sql
+++ b/backend/prisma/migrations/20260523120000_add_share_updated_at/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "Share" ADD COLUMN "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- Backfill existing rows: seed updatedAt with createdAt so old shares aren't all
+-- treated as freshly-active by the deleteUnfinishedShares cron.
+UPDATE "Share" SET "updatedAt" = "createdAt";

--- a/backend/prisma/migrations/20260523120000_add_share_updated_at/migration.sql
+++ b/backend/prisma/migrations/20260523120000_add_share_updated_at/migration.sql
@@ -1,6 +1,2 @@
 -- AlterTable
-ALTER TABLE "Share" ADD COLUMN "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP;
-
--- Backfill existing rows: seed updatedAt with createdAt so old shares aren't all
--- treated as freshly-active by the deleteUnfinishedShares cron.
-UPDATE "Share" SET "updatedAt" = "createdAt";
+ALTER TABLE "Share" ADD COLUMN "updatedAt" DATETIME;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -77,6 +77,7 @@ model OAuthUser {
 model Share {
   id        String   @id @default(uuid())
   createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt @default(now())
 
   name          String?
   uploadLocked  Boolean  @default(false)

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -77,7 +77,7 @@ model OAuthUser {
 model Share {
   id        String   @id @default(uuid())
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt @default(now())
+  updatedAt DateTime? @updatedAt
 
   name          String?
   uploadLocked  Boolean  @default(false)

--- a/backend/src/file/file.service.ts
+++ b/backend/src/file/file.service.ts
@@ -5,6 +5,8 @@ import { ConfigService } from "src/config/config.service";
 import { Readable } from "stream";
 import { PrismaService } from "../prisma/prisma.service";
 
+const UPDATED_AT_THROTTLE_MS = 5 * 60 * 1000;
+
 @Injectable()
 export class FileService {
   constructor(
@@ -37,8 +39,22 @@ export class FileService {
     },
     shareId: string,
   ) {
+    await this.touchShare(shareId);
     const storageService = this.getStorageService();
     return storageService.create(data, chunk, file, shareId);
+  }
+
+  private async touchShare(shareId: string) {
+    const share = await this.prisma.share.findUnique({
+      where: { id: shareId },
+      select: { updatedAt: true },
+    });
+    if (!share) return;
+    if (Date.now() - share.updatedAt.getTime() < UPDATED_AT_THROTTLE_MS) return;
+    await this.prisma.share.update({
+      where: { id: shareId },
+      data: { updatedAt: new Date() },
+    });
   }
 
   async get(shareId: string, fileId: string): Promise<File> {

--- a/backend/src/file/file.service.ts
+++ b/backend/src/file/file.service.ts
@@ -50,7 +50,11 @@ export class FileService {
       select: { updatedAt: true },
     });
     if (!share) return;
-    if (Date.now() - share.updatedAt.getTime() < UPDATED_AT_THROTTLE_MS) return;
+    if (
+      share.updatedAt &&
+      Date.now() - share.updatedAt.getTime() < UPDATED_AT_THROTTLE_MS
+    )
+      return;
     await this.prisma.share.update({
       where: { id: shareId },
       data: { updatedAt: new Date() },

--- a/backend/src/jobs/jobs.service.ts
+++ b/backend/src/jobs/jobs.service.ts
@@ -73,7 +73,7 @@ export class JobsService {
   async deleteUnfinishedShares() {
     const unfinishedShares = await this.prisma.share.findMany({
       where: {
-        createdAt: { lt: moment().subtract(1, "day").toDate() },
+        updatedAt: { lt: moment().subtract(1, "day").toDate() },
         uploadLocked: false,
       },
     });

--- a/backend/src/jobs/jobs.service.ts
+++ b/backend/src/jobs/jobs.service.ts
@@ -71,10 +71,14 @@ export class JobsService {
 
   @Cron("0 */6 * * *")
   async deleteUnfinishedShares() {
+    const cutoff = moment().subtract(1, "day").toDate();
     const unfinishedShares = await this.prisma.share.findMany({
       where: {
-        updatedAt: { lt: moment().subtract(1, "day").toDate() },
         uploadLocked: false,
+        OR: [
+          { updatedAt: { lt: cutoff } },
+          { updatedAt: { equals: null }, createdAt: { lt: cutoff } },
+        ],
       },
     });
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

If you answer Yes and you have used AI in this submission disclose it here.
If you answer No and this PR that appears to be fully or largely AI-generated, it will be closed by the maintainers.

## What's new?
Fix for #76 
Added an updatedAt flag to the share to keep track of updates. This way the cleanup Cron won't remove older shares that have new files bing uploaded when the cleanup cron is running. Because it checks updatedAt for the 24 hour instead of createdAt. 

The updatedAt is updated max every 5 minutes on chunk upload completed. 
## How has it been tested?
i tested 3 scenarios in docker (old stale share being cleaned up, upload during cron not being deleted. and new stale share being cleaned up). 
## Screenshots

N/A
