### PR TITLE
fix: download all (as zip) now works with S3

### DIFF
--- a/backend/src/file/file.service.ts
+++ b/backend/src/file/file.service.ts
@@ -95,7 +95,11 @@ export class FileService {
   }
 
   async getZip(shareId: string): Promise<Readable> {
-    const storageService = this.getStorageService();
+    const share = await this.prisma.share.findFirst({
+      where: { id: shareId },
+      select: { storageProvider: true },
+    });
+    const storageService = this.getStorageService(share?.storageProvider);
     return await storageService.getZip(shareId);
   }
 

--- a/backend/src/file/s3.service.ts
+++ b/backend/src/file/s3.service.ts
@@ -319,95 +319,58 @@ export class S3FileService {
     });
   }
 
-  getZip(shareId: string) {
-    return new Promise<Readable>(async (resolve, reject) => {
-      const s3Instance = this.getS3Instance();
-      const bucketName = this.config.get("s3.bucketName");
-      const compressionLevel = this.config.get("share.zipCompressionLevel");
-
-      const prefix = `${this.getS3Path()}${shareId}/`;
-
-      try {
-        const listResponse = await s3Instance.send(
-          new ListObjectsV2Command({
-            Bucket: bucketName,
-            Prefix: prefix,
-          }),
-        );
-
-        if (!listResponse.Contents || listResponse.Contents.length === 0) {
-          throw new NotFoundException(`No files found for share ${shareId}`);
-        }
-
-        const archive = archiver("zip", {
-          zlib: { level: parseInt(compressionLevel) },
-        });
-
-        archive.on("error", (err) => {
-          this.logger.error("Archive error", err);
-          reject(new InternalServerErrorException(this.i18n.t("file.zipError")));
-        });
-
-        const fileKeys = listResponse.Contents.filter(
-          (object) => object.Key && object.Key !== prefix,
-        ).map((object) => object.Key as string);
-
-        if (fileKeys.length === 0) {
-          throw new NotFoundException(
-            `No valid files found for share ${shareId}`,
-          );
-        }
-
-        let filesAdded = 0;
-
-        const processNextFile = async (index: number) => {
-          if (index >= fileKeys.length) {
-            archive.finalize();
-            return;
-          }
-
-          const key = fileKeys[index];
-          const fileName = key.replace(prefix, "");
-
-          try {
-            const response = await s3Instance.send(
-              new GetObjectCommand({
-                Bucket: bucketName,
-                Key: key,
-              }),
-            );
-
-            if (response.Body instanceof Readable) {
-              const fileStream = response.Body;
-
-              fileStream.on("end", () => {
-                filesAdded++;
-                processNextFile(index + 1);
-              });
-
-              fileStream.on("error", (err) => {
-                this.logger.error(`Error streaming file ${fileName}`, err);
-                processNextFile(index + 1);
-              });
-
-              archive.append(fileStream, { name: fileName });
-            } else {
-              processNextFile(index + 1);
-            }
-          } catch (error) {
-            this.logger.error(`Error processing file ${fileName}`, error);
-            processNextFile(index + 1);
-          }
-        };
-
-        resolve(archive);
-        processNextFile(0);
-      } catch (error) {
-        this.logger.error("Error creating ZIP file", error);
-
-        reject(new InternalServerErrorException(this.i18n.t("file.zipError")));
-      }
+  async getZip(shareId: string) {
+    const files = await this.prisma.file.findMany({
+      where: { shareId },
     });
+
+    if (files.length === 0) {
+      throw new NotFoundException(`No files found for share ${shareId}`);
+    }
+
+    const s3Instance = this.getS3Instance();
+    const bucketName = this.config.get("s3.bucketName");
+    const compressionLevel = this.config.get("share.zipCompressionLevel");
+    const s3Path = this.getS3Path();
+
+    const archive = archiver("zip", {
+      zlib: { level: parseInt(compressionLevel) },
+    });
+
+    archive.on("error", (err) => {
+      this.logger.error("Archive error", err);
+    });
+
+    const processFiles = async () => {
+      for (const file of files) {
+        const key = `${s3Path}${shareId}/${file.name}`;
+        try {
+          const response = await s3Instance.send(
+            new GetObjectCommand({
+              Bucket: bucketName,
+              Key: key,
+            }),
+          );
+
+          if (response.Body instanceof Readable) {
+            const body = response.Body as Readable;
+            archive.append(body, { name: file.name });
+            // Wait for this file to be fully appended before moving to the next one to avoid overwhelming memory/connections
+            await new Promise((resolve, reject) => {
+              body.on("end", resolve);
+              body.on("error", reject);
+            });
+          }
+        } catch (error) {
+          this.logger.error(`Error processing file ${file.name}`, error);
+        }
+      }
+      archive.finalize();
+    };
+
+    processFiles();
+
+    return archive;
   }
 
   getS3Path(): string {

--- a/docs/docs/setup/s3.md
+++ b/docs/docs/setup/s3.md
@@ -29,4 +29,4 @@ When S3 is used in conjunction with ClamAV, the file is first uploaded to the S3
 
 ## ZIP
 
-Creating ZIP archives is not currently supported if you store your files in an S3 bucket.
+Creating ZIP archives is supported when using S3 as a storage provider. Files will be fetched by the backend, zipped, then served to the user. 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

Gemini was used to find the cause of the bug and help refactor the S3 service. Testing and review was done manually.

## What's new?

- The getZip function used when downloading all files in a share now checks the storage provider associated with the share. If a share was created before enabling S3 (or vice versa) it will pick the correct location of the actual files.
- Previously trying to "download all" on shares stored on S3 would just result in a `500` server error. Now it works as expected, files are retrieved by the backend, zipped then served to user.
- Docs previously states ZIPs weren't supported by S3, as they are now, docs have been updated.

## How has it been tested?
- ensured regular single file downloads are unaffected 
- created a share then enabled S3, the share was still accessible and was zipped correctly.
- created a share after enabling S3, the "download all" button now works as expected and provides a zip.

Closes #82
