### PR TITLE
feat(shares): add infinite file retention period

### DIFF
--- a/backend/src/jobs/jobs.service.ts
+++ b/backend/src/jobs/jobs.service.ts
@@ -24,6 +24,11 @@ export class JobsService {
     const fileRetentionPeriod = this.configServer.get(
       "share.fileRetentionPeriod",
     );
+
+    if (fileRetentionPeriod.value === -1) {
+      return;
+    }
+
     const thresholdDate = moment()
       .subtract(fileRetentionPeriod.value, fileRetentionPeriod.unit)
       .toDate();

--- a/backend/src/reverseShare/reverseShare.service.ts
+++ b/backend/src/reverseShare/reverseShare.service.ts
@@ -100,14 +100,13 @@ export class ReverseShareService {
   }
 
   async remove(id: string) {
-    const shares = await this.prisma.share.findMany({
-      where: { reverseShare: { id } },
+    await this.prisma.share.updateMany({
+      where: { reverseShareId: id },
+      data: {
+        reverseShareId: null,
+        expiration: new Date(),
+      },
     });
-
-    for (const share of shares) {
-      await this.prisma.share.delete({ where: { id: share.id } });
-      await this.fileService.deleteAllFiles(share.id);
-    }
 
     await this.prisma.reverseShare.delete({ where: { id } });
   }

--- a/frontend/src/components/admin/configuration/AdminConfigInput.tsx
+++ b/frontend/src/components/admin/configuration/AdminConfigInput.tsx
@@ -309,6 +309,7 @@ const AdminConfigInput = ({
         <TimespanInput
           value={stringToTimespan(configVariable.value)}
           disabled={!configVariable.allowEdit}
+          min={configVariable.key === "share.fileRetentionPeriod" ? -1 : 0}
           onChange={(timespan) =>
             onValueChange(configVariable, timespanToString(timespan))
           }

--- a/frontend/src/components/admin/shares/ManageShareTable.tsx
+++ b/frontend/src/components/admin/shares/ManageShareTable.tsx
@@ -97,7 +97,8 @@ const ManageShareTable = ({
                   </td>
                   {fileRetentionEnabled ? (
                     <td>
-                      {moment(share.expiration).unix() === 0
+                      {moment(share.expiration).unix() === 0 ||
+                      fileRetentionPeriod.value === -1
                         ? "Never"
                         : moment(share.expiration)
                             .add(

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -580,7 +580,7 @@ export default {
     "Allow administrators to access all shares, even if they are password protected, expired or deleted.",
   "admin.config.share.file-retention-period": "File retention period",
   "admin.config.share.file-retention-period.description":
-    "How long files are kept after a share expires or gets deleted. Only useful if the 'Allow admin access to all shares' is also enabled.",
+    "How long files are kept after a share expires or gets deleted. Only useful if the 'Allow admin access to all shares' is also enabled. Set to -1 to keep files forever.",
   "admin.config.smtp.enabled": "Enable",
   "admin.config.smtp.enabled.description":
     "Whether SMTP is enabled. Only set this to true if you entered the host, port, email, user and password of your SMTP server.",


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

Gemini was used to write temporary tests to verify cleanup works as expected.

## What's new?

- The file retention period can now be set to -1 in the admin configuration menu. This prevents the share from ever being deleted after expiry. Should be useful to admins who want to manually review every upload without them deleting.
- Previously file retention didn't work for reverse shares as their cleanup logic was separated. Now instead of being deleted on expiry, shares are unlinked from their reverse share then marked as expired. This effectively "deletes" them for the user, but allows the admin to still view the share in share management.

## How has it been tested?

- Verified any time value can be set to "-1" for the file retention. The admin share management then shows expiry as "never" and files aren't deleted.
- Created a reverse share with 1 minute expiry then uploaded a file to it. After expiry the reverse share and the share disappears for the users, but the admin can still see the share in share management.
- Used Gemini to write some temporary Jest tests for testing cleanup. Have not left these in, I'm intending to expand testing properly (writing actual tests) at a later date.

Closes #84 

