### PR TITLE
feat: email verification

### DIFF
--- a/backend/prisma/migrations/20260603142037_add_email_verification_fields/migration.sql
+++ b/backend/prisma/migrations/20260603142037_add_email_verification_fields/migration.sql
@@ -1,0 +1,28 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "username" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "password" TEXT,
+    "isAdmin" BOOLEAN NOT NULL DEFAULT false,
+    "ldapDN" TEXT,
+    "totpEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "totpVerified" BOOLEAN NOT NULL DEFAULT false,
+    "totpSecret" TEXT,
+    "isActivated" BOOLEAN NOT NULL DEFAULT true,
+    "activationToken" TEXT,
+    "activationTokenExpiresAt" DATETIME
+);
+INSERT INTO "new_User" ("createdAt", "email", "id", "isAdmin", "ldapDN", "password", "totpEnabled", "totpSecret", "totpVerified", "updatedAt", "username") SELECT "createdAt", "email", "id", "isAdmin", "ldapDN", "password", "totpEnabled", "totpSecret", "totpVerified", "updatedAt", "username" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_username_key" ON "User"("username");
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+CREATE UNIQUE INDEX "User_ldapDN_key" ON "User"("ldapDN");
+CREATE UNIQUE INDEX "User_activationToken_key" ON "User"("activationToken");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -28,6 +28,10 @@ model User {
   totpSecret         String?
   resetPasswordToken ResetPasswordToken?
 
+  isActivated              Boolean   @default(true)
+  activationToken          String?   @unique
+  activationTokenExpiresAt DateTime?
+
   oAuthUsers OAuthUser[]
 }
 

--- a/backend/prisma/seed/config.seed.ts
+++ b/backend/prisma/seed/config.seed.ts
@@ -198,6 +198,20 @@ export const configVariables = {
       defaultValue:
         "Hey!\n\n{recipientEmail} downloaded {fileName} from your share: {shareUrl}\n\nPingvin Share 🐧",
     },
+    enableEmailVerification: {
+      type: "boolean",
+      defaultValue: "false",
+      secret: false,
+    },
+    verificationSubject: {
+      type: "string",
+      defaultValue: "Verify your Pingvin Share account",
+    },
+    verificationMessage: {
+      type: "text",
+      defaultValue:
+        "Hey!\n\nYou just signed up for Pingvin Share. Click this link to verify your account: {url}\n\nThe link expires in 24 hours.\n\nPingvin Share 🐧",
+    },
   },
   smtp: {
     enabled: {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -23,6 +23,7 @@ import { AuthRegisterDTO } from "./dto/authRegister.dto";
 import { AuthSignInDTO } from "./dto/authSignIn.dto";
 import { AuthSignInTotpDTO } from "./dto/authSignInTotp.dto";
 import { EnableTotpDTO } from "./dto/enableTotp.dto";
+import { ResendVerificationDTO } from "./dto/resendVerification.dto";
 import { ResetPasswordDTO } from "./dto/resetPassword.dto";
 import { TokenDTO } from "./dto/token.dto";
 import { UpdatePasswordDTO } from "./dto/updatePassword.dto";
@@ -141,6 +142,12 @@ export class AuthController {
   @HttpCode(204)
   async verifyAccount(@Param("token") token: string) {
     await this.authService.verifyAccount(token);
+  }
+
+  @Post("verify/resend")
+  @HttpCode(204)
+  async resendVerification(@Body() dto: ResendVerificationDTO) {
+    await this.authService.resendVerification(dto.email);
   }
 
   @Patch("password")

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -137,6 +137,12 @@ export class AuthController {
     return await this.authService.resetPassword(dto.token, dto.password);
   }
 
+  @Post("verify/:token")
+  @HttpCode(204)
+  async verifyAccount(@Param("token") token: string) {
+    await this.authService.verifyAccount(token);
+  }
+
   @Patch("password")
   @UseGuards(JwtGuard)
   async updatePassword(

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -139,12 +139,24 @@ export class AuthController {
   }
 
   @Post("verify/:token")
+  @Throttle({
+    default: {
+      limit: 20,
+      ttl: 5 * 60,
+    },
+  })
   @HttpCode(204)
   async verifyAccount(@Param("token") token: string) {
     await this.authService.verifyAccount(token);
   }
 
   @Post("verify/resend")
+  @Throttle({
+    default: {
+      limit: 20,
+      ttl: 5 * 60,
+    },
+  })
   @HttpCode(204)
   async resendVerification(@Body() dto: ResendVerificationDTO) {
     await this.authService.resendVerification(dto.email);

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -23,6 +23,7 @@ import { AuthRegisterDTO } from "./dto/authRegister.dto";
 import { AuthSignInDTO } from "./dto/authSignIn.dto";
 import { AuthSignInTotpDTO } from "./dto/authSignInTotp.dto";
 import { EnableTotpDTO } from "./dto/enableTotp.dto";
+import { VerifyAccountDTO } from "./dto/verifyAccount.dto";
 import { ResendVerificationDTO } from "./dto/resendVerification.dto";
 import { ResetPasswordDTO } from "./dto/resetPassword.dto";
 import { TokenDTO } from "./dto/token.dto";
@@ -138,7 +139,7 @@ export class AuthController {
     return await this.authService.resetPassword(dto.token, dto.password);
   }
 
-  @Post("verify/:token")
+  @Post("verify")
   @Throttle({
     default: {
       limit: 20,
@@ -146,8 +147,8 @@ export class AuthController {
     },
   })
   @HttpCode(204)
-  async verifyAccount(@Param("token") token: string) {
-    await this.authService.verifyAccount(token);
+  async verifyAccount(@Body() dto: VerifyAccountDTO) {
+    await this.authService.verifyAccount(dto.token);
   }
 
   @Post("verify/resend")

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -38,7 +38,12 @@ export class AuthService {
   ) {}
   private readonly logger = new Logger(AuthService.name);
 
-  async signUp(dto: AuthRegisterDTO, ip: string, isAdmin?: boolean) {
+  async signUp(
+    dto: AuthRegisterDTO,
+    ip: string,
+    isAdmin?: boolean,
+    skipVerification?: boolean,
+  ) {
     const isFirstUser = (await this.prisma.user.count()) == 0;
     const enableEmailVerification = this.config.get(
       "email.enableEmailVerification",
@@ -52,13 +57,13 @@ export class AuthService {
           username: dto.username,
           password: hash,
           isAdmin: isAdmin ?? isFirstUser,
-          isActivated: isFirstUser || !enableEmailVerification,
+          isActivated: isFirstUser || skipVerification || !enableEmailVerification,
           activationToken:
-            !isFirstUser && enableEmailVerification
+            !isFirstUser && !skipVerification && enableEmailVerification
               ? crypto.randomUUID()
               : null,
           activationTokenExpiresAt:
-            !isFirstUser && enableEmailVerification
+            !isFirstUser && !skipVerification && enableEmailVerification
               ? moment().add(1, "day").toDate()
               : null,
         },

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -246,6 +246,33 @@ export class AuthService {
     });
   }
 
+  async resendVerification(email: string) {
+    const user = await this.prisma.user.findFirst({
+      where: { email },
+    });
+
+    if (!user) {
+      throw new BadRequestException(this.i18n.t("auth.userNotFound"));
+    }
+
+    if (user.isActivated) {
+      throw new BadRequestException(this.i18n.t("auth.userAlreadyActivated"));
+    }
+
+    const activationToken = crypto.randomUUID();
+    const activationTokenExpiresAt = moment().add(1, "day").toDate();
+
+    await this.prisma.user.update({
+      where: { id: user.id },
+      data: {
+        activationToken,
+        activationTokenExpiresAt,
+      },
+    });
+
+    await this.emailService.sendVerificationEmail(user.email, activationToken);
+  }
+
   async updatePassword(user: User, newPassword: string, oldPassword?: string) {
     const isPasswordValid =
       !user.password || (await argon.verify(user.password, oldPassword));

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -8,7 +8,7 @@ import {
   UnauthorizedException,
 } from "@nestjs/common";
 import { JwtService } from "@nestjs/jwt";
-import { User } from "@prisma/client";
+import { Prisma, User } from "@prisma/client";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import * as argon from "argon2";
 import { Request, Response } from "express";
@@ -55,35 +55,39 @@ export class AuthService {
       const needsVerification =
         !isFirstUser && !skipVerification && enableEmailVerification;
 
-      const user = await this.prisma.user.create({
-        data: {
-          email,
-          username: dto.username,
-          password: hash,
-          isAdmin: isAdmin ?? isFirstUser,
-          isActivated: !needsVerification,
-          activationToken: needsVerification ? crypto.randomUUID() : null,
-          activationTokenExpiresAt: needsVerification
-            ? moment().add(1, "day").toDate()
-            : null,
-        },
-      });
+      return await this.prisma.$transaction(async (tx) => {
+        const user = await tx.user.create({
+          data: {
+            email,
+            username: dto.username,
+            password: hash,
+            isAdmin: isAdmin ?? isFirstUser,
+            isActivated: !needsVerification,
+            activationToken: needsVerification ? crypto.randomUUID() : null,
+            activationTokenExpiresAt: needsVerification
+              ? moment().add(1, "day").toDate()
+              : null,
+          },
+        });
 
-      if (user.activationToken) {
-        await this.emailService.sendVerificationEmail(
-          user.email,
-          user.activationToken,
+        if (user.activationToken) {
+          await this.emailService.sendVerificationEmail(
+            user.email,
+            user.activationToken,
+          );
+          return { verificationRequired: true };
+        }
+
+        const { refreshToken, refreshTokenId } = await this.createRefreshToken(
+          user.id,
+          undefined,
+          tx,
         );
-        return { verificationRequired: true };
-      }
+        const accessToken = await this.createAccessToken(user, refreshTokenId);
 
-      const { refreshToken, refreshTokenId } = await this.createRefreshToken(
-        user.id,
-      );
-      const accessToken = await this.createAccessToken(user, refreshTokenId);
-
-      this.logger.log(`User ${user.email} signed up from IP ${ip}`);
-      return { accessToken, refreshToken, user };
+        this.logger.log(`User ${user.email} signed up from IP ${ip}`);
+        return { accessToken, refreshToken, user };
+      });
     } catch (e) {
       if (e instanceof PrismaClientKnownRequestError) {
         if (e.code == "P2002") {
@@ -193,21 +197,23 @@ export class AuthService {
       );
     }
 
-    // Delete old reset password token
-    if (user.resetPasswordToken) {
-      await this.prisma.resetPasswordToken.delete({
-        where: { token: user.resetPasswordToken.token },
+    await this.prisma.$transaction(async (tx) => {
+      // Delete old reset password token
+      if (user.resetPasswordToken) {
+        await tx.resetPasswordToken.delete({
+          where: { token: user.resetPasswordToken.token },
+        });
+      }
+
+      const { token } = await tx.resetPasswordToken.create({
+        data: {
+          expiresAt: moment().add(1, "hour").toDate(),
+          user: { connect: { id: user.id } },
+        },
       });
-    }
 
-    const { token } = await this.prisma.resetPasswordToken.create({
-      data: {
-        expiresAt: moment().add(1, "hour").toDate(),
-        user: { connect: { id: user.id } },
-      },
+      await this.emailService.sendResetPasswordEmail(user.email, token);
     });
-
-    this.emailService.sendResetPasswordEmail(user.email, token);
   }
 
   async resetPassword(token: string, newPassword: string) {
@@ -271,15 +277,17 @@ export class AuthService {
     const activationToken = crypto.randomUUID();
     const activationTokenExpiresAt = moment().add(1, "day").toDate();
 
-    await this.prisma.user.update({
-      where: { id: user.id },
-      data: {
-        activationToken,
-        activationTokenExpiresAt,
-      },
-    });
+    await this.prisma.$transaction(async (tx) => {
+      await tx.user.update({
+        where: { id: user.id },
+        data: {
+          activationToken,
+          activationTokenExpiresAt,
+        },
+      });
 
-    await this.emailService.sendVerificationEmail(user.email, activationToken);
+      await this.emailService.sendVerificationEmail(user.email, activationToken);
+    });
   }
 
   async updatePassword(user: User, newPassword: string, oldPassword?: string) {
@@ -391,9 +399,14 @@ export class AuthService {
     );
   }
 
-  async createRefreshToken(userId: string, idToken?: string) {
+  async createRefreshToken(
+    userId: string,
+    idToken?: string,
+    tx?: Prisma.TransactionClient,
+  ) {
+    const prisma = tx || this.prisma;
     const sessionDuration = this.config.get("general.sessionDuration");
-    const { id, token } = await this.prisma.refreshToken.create({
+    const { id, token } = await prisma.refreshToken.create({
       data: {
         userId,
         expiresAt: moment()

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -40,6 +40,9 @@ export class AuthService {
 
   async signUp(dto: AuthRegisterDTO, ip: string, isAdmin?: boolean) {
     const isFirstUser = (await this.prisma.user.count()) == 0;
+    const enableEmailVerification = this.config.get(
+      "email.enableEmailVerification",
+    );
 
     const hash = dto.password ? await argon.hash(dto.password) : null;
     try {
@@ -49,8 +52,25 @@ export class AuthService {
           username: dto.username,
           password: hash,
           isAdmin: isAdmin ?? isFirstUser,
+          isActivated: isFirstUser || !enableEmailVerification,
+          activationToken:
+            !isFirstUser && enableEmailVerification
+              ? crypto.randomUUID()
+              : null,
+          activationTokenExpiresAt:
+            !isFirstUser && enableEmailVerification
+              ? moment().add(1, "day").toDate()
+              : null,
         },
       });
+
+      if (user.activationToken) {
+        await this.emailService.sendVerificationEmail(
+          user.email,
+          user.activationToken,
+        );
+        return { verificationRequired: true };
+      }
 
       const { refreshToken, refreshTokenId } = await this.createRefreshToken(
         user.id,
@@ -88,6 +108,9 @@ export class AuthService {
       });
 
       if (user?.password && (await argon.verify(user.password, dto.password))) {
+        if (!user.isActivated) {
+          throw new UnauthorizedException(this.i18n.t("auth.accountNotActivated"));
+        }
         this.logger.log(
           `Successful password login for user ${user.email} from IP ${ip}`,
         );
@@ -198,6 +221,28 @@ export class AuthService {
     await this.prisma.user.update({
       where: { id: user.id },
       data: { password: newPasswordHash },
+    });
+  }
+
+  async verifyAccount(token: string) {
+    const user = await this.prisma.user.findFirst({
+      where: { activationToken: token },
+    });
+
+    if (
+      !user ||
+      (user.activationTokenExpiresAt && user.activationTokenExpiresAt < new Date())
+    ) {
+      throw new BadRequestException(this.i18n.t("auth.tokenInvalidOrExpired"));
+    }
+
+    await this.prisma.user.update({
+      where: { id: user.id },
+      data: {
+        isActivated: true,
+        activationToken: null,
+        activationTokenExpiresAt: null,
+      },
     });
   }
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -57,7 +57,8 @@ export class AuthService {
           username: dto.username,
           password: hash,
           isAdmin: isAdmin ?? isFirstUser,
-          isActivated: isFirstUser || skipVerification || !enableEmailVerification,
+          isActivated:
+            isFirstUser || skipVerification || !enableEmailVerification,
           activationToken:
             !isFirstUser && !skipVerification && enableEmailVerification
               ? crypto.randomUUID()
@@ -114,7 +115,9 @@ export class AuthService {
 
       if (user?.password && (await argon.verify(user.password, dto.password))) {
         if (!user.isActivated) {
-          throw new UnauthorizedException(this.i18n.t("auth.accountNotActivated"));
+          throw new UnauthorizedException(
+            this.i18n.t("auth.accountNotActivated"),
+          );
         }
         this.logger.log(
           `Successful password login for user ${user.email} from IP ${ip}`,
@@ -236,7 +239,8 @@ export class AuthService {
 
     if (
       !user ||
-      (user.activationTokenExpiresAt && user.activationTokenExpiresAt < new Date())
+      (user.activationTokenExpiresAt &&
+        user.activationTokenExpiresAt < new Date())
     ) {
       throw new BadRequestException(this.i18n.t("auth.tokenInvalidOrExpired"));
     }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -48,25 +48,24 @@ export class AuthService {
     const enableEmailVerification = this.config.get(
       "email.enableEmailVerification",
     );
+    const email = dto.email.toLowerCase().trim();
 
     const hash = dto.password ? await argon.hash(dto.password) : null;
     try {
+      const needsVerification =
+        !isFirstUser && !skipVerification && enableEmailVerification;
+
       const user = await this.prisma.user.create({
         data: {
-          email: dto.email,
+          email,
           username: dto.username,
           password: hash,
           isAdmin: isAdmin ?? isFirstUser,
-          isActivated:
-            isFirstUser || skipVerification || !enableEmailVerification,
-          activationToken:
-            !isFirstUser && !skipVerification && enableEmailVerification
-              ? crypto.randomUUID()
-              : null,
-          activationTokenExpiresAt:
-            !isFirstUser && !skipVerification && enableEmailVerification
-              ? moment().add(1, "day").toDate()
-              : null,
+          isActivated: !needsVerification,
+          activationToken: needsVerification ? crypto.randomUUID() : null,
+          activationTokenExpiresAt: needsVerification
+            ? moment().add(1, "day").toDate()
+            : null,
         },
       });
 
@@ -107,9 +106,10 @@ export class AuthService {
     }
 
     if (!this.config.get("oauth.disablePassword")) {
+      const email = dto.email?.toLowerCase().trim();
       const user = await this.prisma.user.findFirst({
         where: {
-          OR: [{ email: dto.email }, { username: dto.username }],
+          OR: [{ email }, { username: dto.username }],
         },
       });
 
@@ -172,11 +172,12 @@ export class AuthService {
     return { accessToken, refreshToken };
   }
 
-  async requestResetPassword(email: string) {
+  async requestResetPassword(emailInput: string) {
     if (this.config.get("oauth.disablePassword"))
       throw new ForbiddenException(this.i18n.t("auth.passwordSignInDisabled"));
 
-    const user = await this.prisma.user.findFirst({
+    const email = emailInput.toLowerCase().trim();
+    const user = await this.prisma.user.findUnique({
       where: { email },
       include: { resetPasswordToken: true },
     });
@@ -233,7 +234,7 @@ export class AuthService {
   }
 
   async verifyAccount(token: string) {
-    const user = await this.prisma.user.findFirst({
+    const user = await this.prisma.user.findUnique({
       where: { activationToken: token },
     });
 
@@ -255,14 +256,13 @@ export class AuthService {
     });
   }
 
-  async resendVerification(email: string) {
-    const user = await this.prisma.user.findFirst({
+  async resendVerification(emailInput: string) {
+    const email = emailInput.toLowerCase().trim();
+    const user = await this.prisma.user.findUnique({
       where: { email },
     });
 
-    if (!user) {
-      throw new BadRequestException(this.i18n.t("auth.userNotFound"));
-    }
+    if (!user) return;
 
     if (user.isActivated) {
       throw new BadRequestException(this.i18n.t("auth.userAlreadyActivated"));

--- a/backend/src/auth/dto/resendVerification.dto.ts
+++ b/backend/src/auth/dto/resendVerification.dto.ts
@@ -1,0 +1,7 @@
+import { IsEmail, IsNotEmpty } from "class-validator";
+
+export class ResendVerificationDTO {
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+}

--- a/backend/src/auth/dto/verifyAccount.dto.ts
+++ b/backend/src/auth/dto/verifyAccount.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty } from "class-validator";
+
+export class VerifyAccountDTO {
+  @IsString()
+  @IsNotEmpty()
+  token: string;
+}

--- a/backend/src/email/email.service.ts
+++ b/backend/src/email/email.service.ts
@@ -161,6 +161,21 @@ export class EmailService {
     );
   }
 
+  async sendVerificationEmail(recipientEmail: string, token: string) {
+    const verificationUrl = `${this.config.get(
+      "general.appUrl",
+    )}/auth/verify/${token}`;
+
+    await this.sendMail(
+      recipientEmail,
+      this.config.get("email.verificationSubject"),
+      this.config
+        .get("email.verificationMessage")
+        .replaceAll("\\n", "\n")
+        .replaceAll("{url}", verificationUrl),
+    );
+  }
+
   async sendTestMail(recipientEmail: string) {
     const subject = this.i18n.t("email.testSubject");
     const text = this.i18n.t("email.testText");

--- a/backend/src/i18n/en-US/auth.json
+++ b/backend/src/i18n/en-US/auth.json
@@ -14,5 +14,7 @@
   "userNotFound": "User not found",
   "cannotDeleteLastAdmin": "Cannot delete the last admin user",
   "ldapResetPasswordNotAllowed": "This account can't reset its password here. Please contact your administrator.",
-  "userAlreadyExists": "A user with this {field} already exists"
+  "userAlreadyExists": "A user with this {field} already exists",
+  "accountNotActivated": "Account not activated. Please verify your email.",
+  "userAlreadyActivated": "User already activated"
 }

--- a/backend/src/jobs/jobs.service.ts
+++ b/backend/src/jobs/jobs.service.ts
@@ -154,4 +154,27 @@ export class JobsService {
       this.logger.log(`Deleted ${deletedTokensCount} expired refresh tokens`);
     }
   }
+
+  @Cron("0 * * * *")
+  async deleteUnactivatedUsers() {
+    const cutoff = moment().subtract(24, "hours").toDate();
+    const unactivatedUsers = await this.prisma.user.findMany({
+      where: {
+        isActivated: false,
+        createdAt: { lt: cutoff },
+      },
+      include: { shares: true },
+    });
+
+    for (const user of unactivatedUsers) {
+      await Promise.all(
+        user.shares.map((share) => this.fileService.deleteAllFiles(share.id)),
+      );
+      await this.prisma.user.delete({ where: { id: user.id } });
+    }
+
+    if (unactivatedUsers.length > 0) {
+      this.logger.log(`Deleted ${unactivatedUsers.length} unactivated users`);
+    }
+  }
 }

--- a/backend/src/oauth/oauth.service.ts
+++ b/backend/src/oauth/oauth.service.ts
@@ -182,6 +182,7 @@ export class OAuthService {
       },
       ip,
       user.isAdmin,
+      true,
     );
 
     await this.prisma.oAuthUser.create({

--- a/backend/src/user/dto/createUser.dto.ts
+++ b/backend/src/user/dto/createUser.dto.ts
@@ -6,6 +6,10 @@ export class CreateUserDTO extends UserDTO {
   @Allow()
   isAdmin: boolean;
 
+  @Allow()
+  @IsOptional()
+  isActivated: boolean;
+
   @MinLength(8)
   @IsOptional()
   password: string;

--- a/backend/src/user/dto/user.dto.ts
+++ b/backend/src/user/dto/user.dto.ts
@@ -27,6 +27,9 @@ export class UserDTO {
   isAdmin: boolean;
 
   @Expose()
+  isActivated: boolean;
+
+  @Expose()
   isLdap: boolean;
 
   ldapDN?: string;

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -35,22 +35,30 @@ export class UserSevice {
 
   async create(dto: CreateUserDTO) {
     let hash: string;
+    let randomPassword;
 
     // The password can be undefined if the user is invited by an admin
     if (!dto.password) {
-      const randomPassword = crypto.randomUUID();
+      randomPassword = crypto.randomUUID();
       hash = await argon.hash(randomPassword);
-      await this.emailService.sendInviteEmail(dto.email, randomPassword);
     } else {
       hash = await argon.hash(dto.password);
     }
 
     try {
-      return await this.prisma.user.create({
-        data: {
-          ...dto,
-          password: hash,
-        },
+      return await this.prisma.$transaction(async (tx) => {
+        const user = await tx.user.create({
+          data: {
+            ...dto,
+            password: hash,
+          },
+        });
+
+        if (randomPassword) {
+          await this.emailService.sendInviteEmail(dto.email, randomPassword);
+        }
+
+        return user;
       });
     } catch (e) {
       if (e instanceof PrismaClientKnownRequestError) {

--- a/frontend/src/components/admin/configuration/AdminConfigInput.tsx
+++ b/frontend/src/components/admin/configuration/AdminConfigInput.tsx
@@ -289,24 +289,26 @@ const AdminConfigInput = ({
           w={201}
         />
       )}
-      {configVariable.type == "boolean" && (isEmailShareConfig || isEmailVerificationConfig) && (
-        <>
-          <Switch
-            disabled={!isSmtpEnabled}
-            {...form.getInputProps("booleanValue", { type: "checkbox" })}
-            onChange={(e) => onValueChange(configVariable, e.target.checked)}
-          />
-        </>
-      )}
-      {configVariable.type == "boolean" && !(isEmailShareConfig || isEmailVerificationConfig) && (
-        <>
-          <Switch
-            disabled={!configVariable.allowEdit}
-            {...form.getInputProps("booleanValue", { type: "checkbox" })}
-            onChange={(e) => onValueChange(configVariable, e.target.checked)}
-          />
-        </>
-      )}
+      {configVariable.type == "boolean" &&
+        (isEmailShareConfig || isEmailVerificationConfig) && (
+          <>
+            <Switch
+              disabled={!isSmtpEnabled}
+              {...form.getInputProps("booleanValue", { type: "checkbox" })}
+              onChange={(e) => onValueChange(configVariable, e.target.checked)}
+            />
+          </>
+        )}
+      {configVariable.type == "boolean" &&
+        !(isEmailShareConfig || isEmailVerificationConfig) && (
+          <>
+            <Switch
+              disabled={!configVariable.allowEdit}
+              {...form.getInputProps("booleanValue", { type: "checkbox" })}
+              onChange={(e) => onValueChange(configVariable, e.target.checked)}
+            />
+          </>
+        )}
       {configVariable.type == "timespan" && (
         <TimespanInput
           value={stringToTimespan(configVariable.value)}

--- a/frontend/src/components/admin/configuration/AdminConfigInput.tsx
+++ b/frontend/src/components/admin/configuration/AdminConfigInput.tsx
@@ -49,9 +49,11 @@ const AdminConfigInput = ({
     configVariable.key === "general.defaultLanguage";
   const isEmailShareConfig =
     configVariable.key === "email.enableShareEmailRecipients";
+  const isEmailVerificationConfig =
+    configVariable.key === "email.enableEmailVerification";
   let isSmtpEnabled = false;
 
-  if (isEmailShareConfig) {
+  if (isEmailShareConfig || isEmailVerificationConfig) {
     isSmtpEnabled =
       optionalConfigVariables?.find((config) => config.key === "smtp.enabled")
         ?.value === "true";
@@ -287,7 +289,7 @@ const AdminConfigInput = ({
           w={201}
         />
       )}
-      {configVariable.type == "boolean" && isEmailShareConfig && (
+      {configVariable.type == "boolean" && (isEmailShareConfig || isEmailVerificationConfig) && (
         <>
           <Switch
             disabled={!isSmtpEnabled}
@@ -296,7 +298,7 @@ const AdminConfigInput = ({
           />
         </>
       )}
-      {configVariable.type == "boolean" && !isEmailShareConfig && (
+      {configVariable.type == "boolean" && !(isEmailShareConfig || isEmailVerificationConfig) && (
         <>
           <Switch
             disabled={!configVariable.allowEdit}

--- a/frontend/src/components/admin/users/showUpdateUserModal.tsx
+++ b/frontend/src/components/admin/users/showUpdateUserModal.tsx
@@ -46,6 +46,7 @@ const Body = ({
       username: user.username,
       email: user.email,
       isAdmin: user.isAdmin,
+      isActivated: user.isActivated,
     },
     validate: yupResolver(
       yup.object().shape({
@@ -98,6 +99,13 @@ const Body = ({
             labelPosition="left"
             label={t("admin.users.edit.update.admin-privileges")}
             {...accountForm.getInputProps("isAdmin", { type: "checkbox" })}
+          />
+          <Switch
+            mt="xs"
+            labelPosition="left"
+            label={t("admin.users.edit.update.email-verified")}
+            {...accountForm.getInputProps("isActivated", { type: "checkbox" })}
+            disabled={user.isActivated}
           />
         </Stack>
       </form>

--- a/frontend/src/components/auth/SignUpForm.tsx
+++ b/frontend/src/components/auth/SignUpForm.tsx
@@ -51,7 +51,10 @@ const SignUpForm = () => {
       .signUp(email.trim(), username.trim(), password.trim())
       .then(async (response) => {
         if (response.data.verificationRequired) {
-          router.replace("/auth/verify/info");
+          router.replace({
+            pathname: "/auth/verify/info",
+            query: { email: email.trim() },
+          });
         } else {
           const user = await refreshUser();
           if (user?.isAdmin) {

--- a/frontend/src/components/auth/SignUpForm.tsx
+++ b/frontend/src/components/auth/SignUpForm.tsx
@@ -49,12 +49,16 @@ const SignUpForm = () => {
   const signUp = async (email: string, username: string, password: string) => {
     await authService
       .signUp(email.trim(), username.trim(), password.trim())
-      .then(async () => {
-        const user = await refreshUser();
-        if (user?.isAdmin) {
-          router.replace("/admin/intro");
+      .then(async (response) => {
+        if (response.data.verificationRequired) {
+          router.replace("/auth/verify/info");
         } else {
-          router.replace("/upload");
+          const user = await refreshUser();
+          if (user?.isAdmin) {
+            router.replace("/admin/intro");
+          } else {
+            router.replace("/upload");
+          }
         }
       })
       .catch(toast.axiosError);

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -63,6 +63,19 @@ export default {
   "signup.input.email.placeholder": "Your email",
   "signup.button.submit": "Let's get started",
 
+  // /auth/verify
+  "verify.title": "Verify Account",
+  "verify.success": "Your account has been successfully verified! You can now sign in.",
+  "verify.error": "The verification link is invalid or has expired.",
+  "verify.button.signin": "Go to Sign In",
+  "verify.info.title": "Account Verification",
+  "verify.info.description":
+    "Email verification is enabled. We've sent a verification link to your email address. Please click the link to activate your account.",
+  "verify.info.note": "If you don't receive the email within a few minutes, please check your spam folder.",
+  "verify.info.resend.button": "Resend verification email",
+  "verify.info.resend.success": "Verification email resent successfully.",
+  "verify.info.resend.error": "Failed to resend verification email.",
+
   // END /auth/signup
 
   // /auth/totp
@@ -547,6 +560,15 @@ export default {
     "Download notification message",
   "admin.config.email.share-download-notification-message.description":
     "Message which gets sent to the share creator when a recipient downloads a file. Available variables:\n {recipientEmail} - The email of the recipient\n {fileName} - The downloaded file name\n {shareUrl} - The URL of the share",
+  "admin.config.email.enable-email-verification": "Enable email verification",
+  "admin.config.email.enable-email-verification.description":
+    "Whether to require users to verify their email address before being able to sign in. This can only be enabled if SMTP is activated.",
+  "admin.config.email.verification-subject": "Verification subject",
+  "admin.config.email.verification-subject.description":
+    "Subject of the email which gets sent to the user when they sign up.",
+  "admin.config.email.verification-message": "Verification message",
+  "admin.config.email.verification-message.description":
+    "Message which gets sent to the user when they sign up. {url} will be replaced with the verification URL.",
   "admin.config.share.allow-registration": "Allow registration",
   "admin.config.share.allow-registration.description":
     "Whether registration is allowed",

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -267,6 +267,7 @@ export default {
 
   "admin.users.edit.update.title": "Edit user: {username}",
   "admin.users.edit.update.admin-privileges": "Admin privileges",
+  "admin.users.edit.update.email-verified": "Email verified",
   "admin.users.edit.update.change-password.title": "Change password",
   "admin.users.edit.update.change-password.field": "New password",
   "admin.users.edit.update.change-password.button": "Save new password",

--- a/frontend/src/pages/auth/verify/[token].tsx
+++ b/frontend/src/pages/auth/verify/[token].tsx
@@ -1,0 +1,72 @@
+import { Container, Title, Text, Button, Paper, Stack, Loader, Center } from "@mantine/core";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { FormattedMessage } from "react-intl";
+import authService from "../../../services/auth.service";
+import toast from "../../../utils/toast.util";
+import useTranslate from "../../../hooks/useTranslate.hook";
+import Meta from "../../../components/Meta";
+
+export default function VerifyAccount() {
+  const router = useRouter();
+  const { token } = router.query;
+  const t = useTranslate();
+  const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
+
+  useEffect(() => {
+    if (!token) return;
+
+    authService
+      .verifyAccount(token as string)
+      .then(() => setStatus("success"))
+      .catch((e) => {
+        toast.axiosError(e);
+        setStatus("error");
+      });
+  }, [token]);
+
+  return (
+    <>
+      <Meta title={t("verify.title")} />
+      <Container size={420} my={40}>
+        <Title order={2} align="center" weight={900}>
+          <FormattedMessage id="verify.title" />
+        </Title>
+        <Paper withBorder shadow="md" p={30} mt={30} radius="md">
+          <Stack align="center">
+            {status === "loading" && <Loader />}
+            {status === "success" && (
+              <>
+                <Text align="center">
+                  <FormattedMessage
+                    id="verify.success"
+                  />
+                </Text>
+                <Button fullWidth mt="xl" onClick={() => router.replace("/auth/signIn")}>
+                  <FormattedMessage id="verify.button.signin" />
+                </Button>
+              </>
+            )}
+            {status === "error" && (
+              <>
+                <Text align="center" color="red">
+                  <FormattedMessage
+                    id="verify.error"
+                  />
+                </Text>
+                <Button
+                  fullWidth
+                  mt="xl"
+                  variant="light"
+                  onClick={() => router.replace("/auth/signIn")}
+                >
+                  <FormattedMessage id="verify.button.signin" />
+                </Button>
+              </>
+            )}
+          </Stack>
+        </Paper>
+      </Container>
+    </>
+  );
+}

--- a/frontend/src/pages/auth/verify/[token].tsx
+++ b/frontend/src/pages/auth/verify/[token].tsx
@@ -1,4 +1,13 @@
-import { Container, Title, Text, Button, Paper, Stack, Loader, Center } from "@mantine/core";
+import {
+  Container,
+  Title,
+  Text,
+  Button,
+  Paper,
+  Stack,
+  Loader,
+  Center,
+} from "@mantine/core";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { FormattedMessage } from "react-intl";
@@ -11,7 +20,9 @@ export default function VerifyAccount() {
   const router = useRouter();
   const { token } = router.query;
   const t = useTranslate();
-  const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
+  const [status, setStatus] = useState<"loading" | "success" | "error">(
+    "loading",
+  );
 
   useEffect(() => {
     if (!token) return;
@@ -42,8 +53,14 @@ export default function VerifyAccount() {
                     id="verify.success"
                   />
                 </Text>
-                <Button fullWidth mt="xl" onClick={() => router.replace("/auth/signIn")}>
-                  <FormattedMessage id="verify.button.signin" />
+                <Button
+                  fullWidth
+                  mt="xl"
+                  onClick={() => router.replace("/auth/signIn")}
+                >
+                  <FormattedMessage
+                    id="verify.button.signin"
+                  />
                 </Button>
               </>
             )}
@@ -60,7 +77,10 @@ export default function VerifyAccount() {
                   variant="light"
                   onClick={() => router.replace("/auth/signIn")}
                 >
-                  <FormattedMessage id="verify.button.signin" />
+                  <FormattedMessage
+                    id="verify.button.signin"
+                    defaultMessage="Go to Sign In"
+                  />
                 </Button>
               </>
             )}

--- a/frontend/src/pages/auth/verify/info.tsx
+++ b/frontend/src/pages/auth/verify/info.tsx
@@ -32,7 +32,9 @@ export default function VerificationInfo() {
       <Meta title={t("verify.info.title")} />
       <Container size={420} my={40}>
         <Title order={2} align="center" weight={900}>
-          <FormattedMessage id="verify.info.title" />
+          <FormattedMessage
+            id="verify.info.title"
+          />
         </Title>
         <Paper withBorder shadow="md" p={30} mt={30} radius="md">
           <Stack align="center">
@@ -64,7 +66,9 @@ export default function VerificationInfo() {
                 />
               </Button>
               <Button fullWidth onClick={() => router.replace("/auth/signIn")}>
-                <FormattedMessage id="verify.button.signin" defaultMessage="Go to Sign In" />
+                <FormattedMessage
+                  id="verify.button.signin"
+                />
               </Button>
             </Stack>
           </Stack>

--- a/frontend/src/pages/auth/verify/info.tsx
+++ b/frontend/src/pages/auth/verify/info.tsx
@@ -1,0 +1,38 @@
+import { Container, Title, Text, Button, Paper, Stack } from "@mantine/core";
+import { useRouter } from "next/router";
+import { FormattedMessage } from "react-intl";
+import useTranslate from "../../../hooks/useTranslate.hook";
+import Meta from "../../../components/Meta";
+
+export default function VerificationInfo() {
+  const router = useRouter();
+  const t = useTranslate();
+
+  return (
+    <>
+      <Meta title={t("verify.info.title")} />
+      <Container size={420} my={40}>
+        <Title order={2} align="center" weight={900}>
+          <FormattedMessage id="verify.info.title" />
+        </Title>
+        <Paper withBorder shadow="md" p={30} mt={30} radius="md">
+          <Stack align="center">
+            <Text align="center">
+              <FormattedMessage
+                id="verify.info.description"
+              />
+            </Text>
+            <Text align="center" size="sm" color="dimmed">
+              <FormattedMessage
+                id="verify.info.note"
+              />
+            </Text>
+            <Button fullWidth mt="xl" onClick={() => router.replace("/auth/signIn")}>
+              <FormattedMessage id="verify.button.signin" />
+            </Button>
+          </Stack>
+        </Paper>
+      </Container>
+    </>
+  );
+}

--- a/frontend/src/pages/auth/verify/info.tsx
+++ b/frontend/src/pages/auth/verify/info.tsx
@@ -1,12 +1,31 @@
 import { Container, Title, Text, Button, Paper, Stack } from "@mantine/core";
 import { useRouter } from "next/router";
+import { useState } from "react";
 import { FormattedMessage } from "react-intl";
+import authService from "../../../services/auth.service";
+import toast from "../../../utils/toast.util";
 import useTranslate from "../../../hooks/useTranslate.hook";
 import Meta from "../../../components/Meta";
 
 export default function VerificationInfo() {
   const router = useRouter();
+  const { email } = router.query;
   const t = useTranslate();
+  const [loading, setLoading] = useState(false);
+
+  const resendEmail = async () => {
+    if (!email) return;
+    setLoading(true);
+    authService
+      .resendVerification(email as string)
+      .then(() => {
+        toast.success(t("verify.info.resend.success"));
+      })
+      .catch((e) => {
+        toast.axiosError(e);
+      })
+      .finally(() => setLoading(false));
+  };
 
   return (
     <>
@@ -22,14 +41,32 @@ export default function VerificationInfo() {
                 id="verify.info.description"
               />
             </Text>
+            {email && (
+              <Text weight={700} size="sm">
+                {email}
+              </Text>
+            )}
             <Text align="center" size="sm" color="dimmed">
               <FormattedMessage
                 id="verify.info.note"
               />
             </Text>
-            <Button fullWidth mt="xl" onClick={() => router.replace("/auth/signIn")}>
-              <FormattedMessage id="verify.button.signin" />
-            </Button>
+            <Stack w="100%" mt="xl">
+              <Button
+                variant="light"
+                onClick={resendEmail}
+                loading={loading}
+                disabled={!email}
+                fullWidth
+              >
+                <FormattedMessage
+                  id="verify.info.resend.button"
+                />
+              </Button>
+              <Button fullWidth onClick={() => router.replace("/auth/signIn")}>
+                <FormattedMessage id="verify.button.signin" defaultMessage="Go to Sign In" />
+              </Button>
+            </Stack>
           </Stack>
         </Paper>
       </Container>

--- a/frontend/src/services/auth.service.ts
+++ b/frontend/src/services/auth.service.ts
@@ -64,6 +64,10 @@ const verifyAccount = async (token: string) => {
   await api.post(`/auth/verify/${token}`);
 };
 
+const resendVerification = async (email: string) => {
+  await api.post("/auth/verify/resend", { email });
+};
+
 const updatePassword = async (oldPassword: string, password: string) => {
   await api.patch("/auth/password", { oldPassword, password });
 };
@@ -110,6 +114,7 @@ export default {
   requestResetPassword,
   resetPassword,
   verifyAccount,
+  resendVerification,
   enableTOTP,
   verifyTOTP,
   disableTOTP,

--- a/frontend/src/services/auth.service.ts
+++ b/frontend/src/services/auth.service.ts
@@ -60,6 +60,10 @@ const resetPassword = async (token: string, password: string) => {
   await api.post("/auth/resetPassword", { token, password });
 };
 
+const verifyAccount = async (token: string) => {
+  await api.post(`/auth/verify/${token}`);
+};
+
 const updatePassword = async (oldPassword: string, password: string) => {
   await api.patch("/auth/password", { oldPassword, password });
 };
@@ -105,6 +109,7 @@ export default {
   updatePassword,
   requestResetPassword,
   resetPassword,
+  verifyAccount,
   enableTOTP,
   verifyTOTP,
   disableTOTP,

--- a/frontend/src/services/auth.service.ts
+++ b/frontend/src/services/auth.service.ts
@@ -61,7 +61,7 @@ const resetPassword = async (token: string, password: string) => {
 };
 
 const verifyAccount = async (token: string) => {
-  await api.post(`/auth/verify/${token}`);
+  await api.post(`/auth/verify`, { token });
 };
 
 const resendVerification = async (email: string) => {

--- a/frontend/src/types/user.type.ts
+++ b/frontend/src/types/user.type.ts
@@ -3,6 +3,7 @@ type User = {
   username: string;
   email: string;
   isAdmin: boolean;
+  isActivated: boolean;
   isLdap: boolean;
   totpVerified: boolean;
   hasPassword: boolean;
@@ -20,6 +21,7 @@ export type UpdateUser = {
   email?: string;
   password?: string;
   isAdmin?: boolean;
+  isActivated?: boolean;
 };
 
 export type UpdateCurrentUser = {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

GitHub Copilot was used to assistivetly write code with autocomplete. Gemini was used to review code and suggest improvements and changes.

## What's new?

- Admins can now enable email verification in the Configuration -> Email menu. This toggle will be greyed out if SMTP isn't configured and enabled.
  - Existing users are unaffected, verification is only part of the sign up process.
  - Unverified accounts will be purged after 24 hours. 
  - Admins can manually mark accounts as verified in user management but can't 'unverify' (toggle only works one way, as verify email can't be resent by admin).
  - Admins can still manually create users, these don't need verification.
  - Oauth sign ups bypass verification.
  - Admins can customise the subject and contents of the email verification email that gets sent to the user.
  - If enabled, on sign up users will be sent an email containing an unique verification link. After navigating to this link users can *then* sign in regularly.

## How has it been tested?
- Without SMTP enabled the verification toggle can't be modified.
- Checked expected user flow, signed up, got verification email, verified and could sign in.
- Checked users can't sign in until after verification, if they try a pop-up appears with the error: "Account not activated. Please verify your email."
- Checked when the SMTP server is down/erroring, then on signup the account doesn't get created and an "internal server error" pop-up is shown.
- Checked if an admin manually creates an account it shows as verified.
- Checked the verification status can only be toggled one way by the admin, they can't unverify an account.

A rebase broke all the commit timestamps, I did spend more than nine minutes developing and testing this.

## Screenshots

<img width="1024" height="801" alt="Image1" src="https://github.com/user-attachments/assets/d9828900-64a8-4c09-996e-30e3f133b07a" />
<img width="1024" height="931" alt="Image2" src="https://github.com/user-attachments/assets/dd9cd59e-734f-412d-9941-1926b7043c1d" />
<img width="1024" height="446" alt="Image3" src="https://github.com/user-attachments/assets/944711a0-1794-4923-ba49-e18959eecca4" />


Closes #66 
