### PR TITLE
fix(email): localize fromNow/fallbacks via general.defaultLanguage

### DIFF
--- a/backend/src/email/email.service.ts
+++ b/backend/src/email/email.service.ts
@@ -70,7 +70,7 @@ export class EmailService {
     const shareUrl = `${this.config.get(
       "general.appUrl",
     )}/s/${shareId}?recipient=${encodeURIComponent(recipientId)}`;
-    const lang = "";
+    const lang = this.config.get("general.defaultLanguage");
     const locale = this.i18n.translate("email.locale", { lang });
 
     await this.sendMail(


### PR DESCRIPTION
Share-recipient emails always render the expiry time in English, ignoring the configured language. This PR fixes that (tested with de-de locale).