### PR TITLE
feat(reverse share): add simple mode policy in config

### DIFF
--- a/backend/prisma/seed/config.seed.ts
+++ b/backend/prisma/seed/config.seed.ts
@@ -112,9 +112,9 @@ export const configVariables = {
       defaultValue: "false",
       secret: false,
     },
-    forceReverseShareSimpleModeValue: {
-      type: "string",
-      defaultValue: "undefined",
+    reverseShareSimpleOnly: {
+      type: "boolean",
+      defaultValue: "false",
       secret: false,
     },
     allowAdminAccessAllShares: {

--- a/backend/prisma/seed/config.seed.ts
+++ b/backend/prisma/seed/config.seed.ts
@@ -112,6 +112,11 @@ export const configVariables = {
       defaultValue: "false",
       secret: false,
     },
+    forceReverseShareSimpleModeValue: {
+      type: "string",
+      defaultValue: "undefined",
+      secret: false,
+    },
     allowAdminAccessAllShares: {
       type: "boolean",
       defaultValue: "false",
@@ -546,7 +551,7 @@ async function migrateConfigVariables() {
   for (const existingConfigVariable of existingConfigVariables) {
     const configVariable =
       configVariables[existingConfigVariable.category]?.[
-        existingConfigVariable.name
+      existingConfigVariable.name
       ];
 
     // Delete the config variable if it doesn't exist in the seed

--- a/frontend/src/components/admin/configuration/AdminConfigInput.tsx
+++ b/frontend/src/components/admin/configuration/AdminConfigInput.tsx
@@ -51,8 +51,6 @@ const AdminConfigInput = ({
     configVariable.key === "email.enableShareEmailRecipients";
   const isEmailVerificationConfig =
     configVariable.key === "email.enableEmailVerification";
-  const isShareForceReverseShareSimpleModeConfig =
-    configVariable.key === "share.forceReverseShareSimpleModeValue";
   let isSmtpEnabled = false;
 
   if (isEmailShareConfig || isEmailVerificationConfig) {
@@ -247,18 +245,6 @@ const AdminConfigInput = ({
             ]}
             value={form.values.stringValue}
             onChange={(value) => onValueChange(configVariable, value)}
-          />
-        ) : isShareForceReverseShareSimpleModeConfig ? (
-          <Select
-            style={{
-              width: "100%",
-            }}
-            disabled={!configVariable.allowEdit}
-            data={["undefined", "simple", "advanced"]}
-            value={form.values.stringValue}
-            placeholder={configVariable.defaultValue}
-            onChange={(value) => onValueChange(configVariable, value ?? "")}
-            allowDeselect={false}
           />
         ) : (
           <TextInput

--- a/frontend/src/components/admin/configuration/AdminConfigInput.tsx
+++ b/frontend/src/components/admin/configuration/AdminConfigInput.tsx
@@ -51,6 +51,8 @@ const AdminConfigInput = ({
     configVariable.key === "email.enableShareEmailRecipients";
   const isEmailVerificationConfig =
     configVariable.key === "email.enableEmailVerification";
+  const isShareForceReverseShareSimpleModeConfig =
+    configVariable.key === "share.forceReverseShareSimpleModeValue";
   let isSmtpEnabled = false;
 
   if (isEmailShareConfig || isEmailVerificationConfig) {
@@ -245,6 +247,18 @@ const AdminConfigInput = ({
             ]}
             value={form.values.stringValue}
             onChange={(value) => onValueChange(configVariable, value)}
+          />
+        ) : isShareForceReverseShareSimpleModeConfig ? (
+          <Select
+            style={{
+              width: "100%",
+            }}
+            disabled={!configVariable.allowEdit}
+            data={["undefined", "simple", "advanced"]}
+            value={form.values.stringValue}
+            placeholder={configVariable.defaultValue}
+            onChange={(value) => onValueChange(configVariable, value ?? "")}
+            allowDeselect={false}
           />
         ) : (
           <TextInput

--- a/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
+++ b/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
@@ -31,6 +31,7 @@ const showCreateReverseShareModal = (
   showSendEmailNotificationOption: boolean,
   maxExpiration: Timespan,
   defaultExpiration: Timespan,
+  forceReverseShareSimpleModeValue: string,
   appUrl: string,
   defaultAppUrl: string,
   getReverseShares: () => void,
@@ -45,6 +46,7 @@ const showCreateReverseShareModal = (
         getReverseShares={getReverseShares}
         maxExpiration={maxExpiration}
         defaultExpiration={defaultExpiration}
+        forceReverseShareSimpleModeValue={forceReverseShareSimpleModeValue}
         appUrl={appUrl}
         defaultAppUrl={defaultAppUrl}
       />
@@ -57,6 +59,7 @@ const Body = ({
   showSendEmailNotificationOption,
   maxExpiration,
   defaultExpiration,
+  forceReverseShareSimpleModeValue,
   appUrl,
   defaultAppUrl,
 }: {
@@ -64,6 +67,7 @@ const Body = ({
   showSendEmailNotificationOption: boolean;
   maxExpiration: Timespan;
   defaultExpiration: Timespan;
+  forceReverseShareSimpleModeValue: string | undefined;
   appUrl: string;
   defaultAppUrl: string;
 }) => {
@@ -81,7 +85,7 @@ const Body = ({
       sendEmailNotification: false,
       expiration_num: defaultTimespan.value,
       expiration_unit: `-${defaultTimespan.unit}` as string,
-      simplified: !!(getCookie("reverse-share.simplified") ?? false),
+      simplified: forceReverseShareSimpleModeValue !== "undefined" ? forceReverseShareSimpleModeValue === "simple" : !!(getCookie("reverse-share.simplified") ?? false),
       publicAccess: !!(getCookie("reverse-share.public-access") ?? true),
     },
     validate: yupResolver(
@@ -253,17 +257,19 @@ const Body = ({
               })}
             />
           )}
-          <Switch
-            mt="xs"
-            labelPosition="left"
-            label={t("account.reverseShares.modal.simplified")}
-            description={t(
-              "account.reverseShares.modal.simplified.description",
-            )}
-            {...form.getInputProps("simplified", {
-              type: "checkbox",
-            })}
-          />
+          {forceReverseShareSimpleModeValue === "undefined" &&
+            <Switch
+              mt="xs"
+              labelPosition="left"
+              label={t("account.reverseShares.modal.simplified")}
+              description={t(
+                "account.reverseShares.modal.simplified.description",
+              )}
+              {...form.getInputProps("simplified", {
+                type: "checkbox",
+              })}
+            />
+          }
           <Switch
             mt="xs"
             labelPosition="left"
@@ -279,8 +285,8 @@ const Body = ({
             <FormattedMessage id="common.button.create" />
           </Button>
         </Stack>
-      </form>
-    </Group>
+      </form >
+    </Group >
   );
 };
 

--- a/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
+++ b/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
@@ -31,7 +31,7 @@ const showCreateReverseShareModal = (
   showSendEmailNotificationOption: boolean,
   maxExpiration: Timespan,
   defaultExpiration: Timespan,
-  forceReverseShareSimpleModeValue: string,
+  reverseShareSimpleOnly: boolean,
   appUrl: string,
   defaultAppUrl: string,
   getReverseShares: () => void,
@@ -46,7 +46,7 @@ const showCreateReverseShareModal = (
         getReverseShares={getReverseShares}
         maxExpiration={maxExpiration}
         defaultExpiration={defaultExpiration}
-        forceReverseShareSimpleModeValue={forceReverseShareSimpleModeValue}
+        reverseShareSimpleOnly={reverseShareSimpleOnly}
         appUrl={appUrl}
         defaultAppUrl={defaultAppUrl}
       />
@@ -59,7 +59,7 @@ const Body = ({
   showSendEmailNotificationOption,
   maxExpiration,
   defaultExpiration,
-  forceReverseShareSimpleModeValue,
+  reverseShareSimpleOnly,
   appUrl,
   defaultAppUrl,
 }: {
@@ -67,7 +67,7 @@ const Body = ({
   showSendEmailNotificationOption: boolean;
   maxExpiration: Timespan;
   defaultExpiration: Timespan;
-  forceReverseShareSimpleModeValue: string | undefined;
+  reverseShareSimpleOnly: boolean;
   appUrl: string;
   defaultAppUrl: string;
 }) => {
@@ -85,7 +85,7 @@ const Body = ({
       sendEmailNotification: false,
       expiration_num: defaultTimespan.value,
       expiration_unit: `-${defaultTimespan.unit}` as string,
-      simplified: forceReverseShareSimpleModeValue !== "undefined" ? forceReverseShareSimpleModeValue === "simple" : !!(getCookie("reverse-share.simplified") ?? false),
+      simplified: !reverseShareSimpleOnly ? false : !!(getCookie("reverse-share.simplified") ?? false),
       publicAccess: !!(getCookie("reverse-share.public-access") ?? true),
     },
     validate: yupResolver(
@@ -257,7 +257,7 @@ const Body = ({
               })}
             />
           )}
-          {forceReverseShareSimpleModeValue === "undefined" &&
+          {!reverseShareSimpleOnly &&
             <Switch
               mt="xs"
               labelPosition="left"

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -599,6 +599,9 @@ export default {
     "The share creation modal automatically appears when a user selects files, eliminating the need to manually click the button.",
   "admin.config.share.allow-admin-access-all-shares":
     "Allow admin access to all shares",
+  "admin.config.share.force-reverse-share-simple-mode-value": "Force reverse share simple mode",
+  "admin.config.share.force-reverse-share-simple-mode-value.description":
+    "Force reverse shares to be created in simple mode or advanced mode. Authorized values are 'simple', 'advanced' or 'none'. If set to 'none', the creator of the reverse share can choose between simple and advanced mode.",
   "admin.config.share.allow-admin-access-all-shares.description":
     "Allow administrators to access all shares, even if they are password protected, expired or deleted.",
   "admin.config.share.file-retention-period": "File retention period",

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -599,9 +599,9 @@ export default {
     "The share creation modal automatically appears when a user selects files, eliminating the need to manually click the button.",
   "admin.config.share.allow-admin-access-all-shares":
     "Allow admin access to all shares",
-  "admin.config.share.force-reverse-share-simple-mode-value": "Force reverse share simple mode",
-  "admin.config.share.force-reverse-share-simple-mode-value.description":
-    "Force reverse shares to be created in simple mode or advanced mode. Authorized values are 'simple', 'advanced' or 'none'. If set to 'none', the creator of the reverse share can choose between simple and advanced mode.",
+  "admin.config.share.reverse-share-simple-only": "Force reverse share simple mode",
+  "admin.config.share.reverse-share-simple-only.description":
+    "Force reverse shares to be created in simple mode. If disabled, the creator of the reverse share can choose between simple and advanced mode.",
   "admin.config.share.allow-admin-access-all-shares.description":
     "Allow administrators to access all shares, even if they are password protected, expired or deleted.",
   "admin.config.share.file-retention-period": "File retention period",

--- a/frontend/src/pages/account/reverseShares.tsx
+++ b/frontend/src/pages/account/reverseShares.tsx
@@ -73,7 +73,7 @@ const MyShares = () => {
               config.get("smtp.enabled"),
               config.get("share.maxExpiration"),
               config.get("share.defaultExpiration"),
-              config.get("share.forceReverseShareSimpleModeValue"),
+              config.get("share.reverseShareSimpleOnly"),
               appUrl,
               defaultAppUrl,
               getReverseShares,

--- a/frontend/src/pages/account/reverseShares.tsx
+++ b/frontend/src/pages/account/reverseShares.tsx
@@ -73,6 +73,7 @@ const MyShares = () => {
               config.get("smtp.enabled"),
               config.get("share.maxExpiration"),
               config.get("share.defaultExpiration"),
+              config.get("share.forceReverseShareSimpleModeValue"),
               appUrl,
               defaultAppUrl,
               getReverseShares,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

If you answer Yes and you have used AI in this submission disclose it here.
If you answer No and this PR that appears to be fully or largely AI-generated, it will be closed by the maintainers.

I used AI only for searching into the project, and auto-completion

## What's new?

Added the capability for admin to force the value of the "Simple mode" switch in reverse share's create form

## How has it been tested?

Using the admin config panel, to enable the option, and then creating a reverse share

## Screenshots

<img width="1854" height="904" alt="image" src="https://github.com/user-attachments/assets/14ec51b8-0157-45ee-ac2d-421fa4afb457" />

When the option is set to "simple" or "advanced" :

<img width="453" height="507" alt="image" src="https://github.com/user-attachments/assets/77b4fead-da70-47e2-b3db-bcaa0fe9637b" />

