### PR TITLE
feat(bypass expiration): allow admins to bypass max file expiration

### DIFF
--- a/backend/prisma/seed/config.seed.ts
+++ b/backend/prisma/seed/config.seed.ts
@@ -117,6 +117,11 @@ export const configVariables = {
       defaultValue: "false",
       secret: false,
     },
+    allowAdminBypassMaxExpiration: {
+      type: "boolean",
+      defaultValue: "false",
+      secret: false,
+    },
     fileRetentionPeriod: {
       type: "timespan",
       defaultValue: "0 days",

--- a/backend/src/share/share.service.ts
+++ b/backend/src/share/share.service.ts
@@ -66,7 +66,7 @@ export class ShareService {
       expirationDate = reverseShare.shareExpiration;
     } else {
       expirationDate = this.parseExpiration(share.expiration);
-      this.validateExpiration(expirationDate);
+      this.validateExpiration(expirationDate, user);
     }
 
     fs.mkdirSync(`${SHARE_DIRECTORY}/${share.id}`, {
@@ -328,7 +328,7 @@ export class ShareService {
     let expirationDate: Date | undefined;
     if (body.expiration !== undefined) {
       expirationDate = this.parseExpiration(body.expiration);
-      this.validateExpiration(expirationDate);
+      this.validateExpiration(expirationDate, user);
     }
 
     const data: Prisma.ShareUpdateInput = {
@@ -425,12 +425,13 @@ export class ShareService {
     throw new BadRequestException(this.i18n.t("share.invalidExpiration"));
   }
 
-  private validateExpiration(expiration: Date) {
+  private validateExpiration(expiration: Date, user: User) {
     const expiresNever = moment(expiration).isSame(0);
     const maxExpiration = this.config.get("share.maxExpiration");
+    const canBypassMaxExpiration = user.isAdmin && this.config.get("share.allowAdminBypassMaxExpiration");
 
     if (
-      maxExpiration.value !== 0 &&
+      maxExpiration.value !== 0 && !canBypassMaxExpiration &&
       (expiresNever ||
         expiration >
           moment().add(maxExpiration.value, maxExpiration.unit).toDate())

--- a/frontend/src/components/upload/modals/showCreateUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCreateUploadModal.tsx
@@ -48,6 +48,7 @@ const showCreateUploadModal = (
     maxExpiration: Timespan;
     defaultExpiration: Timespan;
     shareIdLength: number;
+    allowAdminBypassMaxExpiration: boolean;
     simplified: boolean;
   },
   files: FileUpload[],
@@ -124,6 +125,7 @@ const CreateUploadModalBody = ({
     maxExpiration: Timespan;
     defaultExpiration: Timespan;
     shareIdLength: number;
+    allowAdminBypassMaxExpiration: boolean;
   };
 }) => {
   const modals = useModals();
@@ -196,13 +198,13 @@ const CreateUploadModalBody = ({
 
       if (
         options.maxExpiration.value != 0 &&
-        (form.values.never_expires ||
+        (!options.allowAdminBypassMaxExpiration && (form.values.never_expires ||
           expirationDate.isAfter(
             moment().add(
               options.maxExpiration.value,
               options.maxExpiration.unit,
             ),
-          ))
+          )))
       ) {
         form.setFieldError(
           "expiration_num",
@@ -280,6 +282,7 @@ const CreateUploadModalBody = ({
           >
             {`${options.appUrl !== options.defaultAppUrl ? options.appUrl : window.location.origin}/s/${form.values.link}`}
           </Text>
+          <p>{options.allowAdminBypassMaxExpiration ? "true" : "false"}</p>
           {!options.isReverseShare && (
             <>
               <Grid align={form.errors.expiration_num ? "center" : "flex-end"}>
@@ -345,7 +348,7 @@ const CreateUploadModalBody = ({
                   />
                 </Col>
               </Grid>
-              {options.maxExpiration.value == 0 && (
+              {(options.allowAdminBypassMaxExpiration || options.maxExpiration.value == 0) && (
                 <Checkbox
                   label={t("upload.modal.expires.never-long")}
                   {...form.getInputProps("never_expires")}

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -601,6 +601,8 @@ export default {
     "Allow admin access to all shares",
   "admin.config.share.allow-admin-access-all-shares.description":
     "Allow administrators to access all shares, even if they are password protected, expired or deleted.",
+  "admin.config.share.allow-admin-bypass-max-expiration": "Allow admin to bypass max file expiration",
+  "admin.config.share.allow-admin-bypass-max-expiration.description": "Allow administrators to create shares with an expiration date that exceeds the maximum expiration limit. They can also create shares that never expire, even if the maximum expiration is set to a specific time.",
   "admin.config.share.file-retention-period": "File retention period",
   "admin.config.share.file-retention-period.description":
     "How long files are kept after a share expires or gets deleted. Only useful if the 'Allow admin access to all shares' is also enabled. Set to -1 to keep files forever.",

--- a/frontend/src/pages/upload/index.tsx
+++ b/frontend/src/pages/upload/index.tsx
@@ -151,6 +151,9 @@ const Upload = ({
         maxExpiration: config.get("share.maxExpiration"),
         defaultExpiration: config.get("share.defaultExpiration"),
         shareIdLength: config.get("share.shareIdLength"),
+        allowAdminBypassMaxExpiration: user?.isAdmin && config.get(
+          "share.allowAdminBypassMaxExpiration",
+        ),
         simplified,
       },
       files,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

If you answer Yes and you have used AI in this submission disclose it here.
If you answer No and this PR that appears to be fully or largely AI-generated, it will be closed by the maintainers.

I used AI only for searching into the project, and auto-completion

## What's new?

Added the capability to allow admins to bypass max expiration duration when creating share (only for direct share, not for reverse ones)

## How has it been tested?

Using the web interface, by trying to send a file as admin and as normal user (normal user must respect the fixed limit)

## Screenshots

<img width="1845" height="900" alt="image" src="https://github.com/user-attachments/assets/2021de1e-f591-4778-bffb-e02051626bf6" />

