### PR TITLE
feat: per user share size limits

### DIFF
--- a/backend/prisma/migrations/20260617131434_add_user_share_size_limit/migration.sql
+++ b/backend/prisma/migrations/20260617131434_add_user_share_size_limit/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "shareSizeLimit" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   password String?
   isAdmin  Boolean @default(false)
   ldapDN   String? @unique
+  shareSizeLimit String?
 
   shares        Share[]
   refreshTokens RefreshToken[]

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -286,7 +286,10 @@ export class AuthService {
         },
       });
 
-      await this.emailService.sendVerificationEmail(user.email, activationToken);
+      await this.emailService.sendVerificationEmail(
+        user.email,
+        activationToken,
+      );
     });
   }
 

--- a/backend/src/file/local.service.ts
+++ b/backend/src/file/local.service.ts
@@ -39,7 +39,7 @@ export class LocalFileService {
 
     const share = await this.prisma.share.findUnique({
       where: { id: shareId },
-      include: { files: true, reverseShare: true },
+      include: { files: true, reverseShare: true, creator: true },
     });
 
     if (share.uploadLocked)
@@ -84,11 +84,14 @@ export class LocalFileService {
 
     const shareSizeSum = fileSizeSum + diskFileSize + buffer.byteLength;
 
-    if (
-      shareSizeSum > this.config.get("share.maxSize") ||
-      (share.reverseShare?.maxShareSize &&
-        shareSizeSum > parseInt(share.reverseShare.maxShareSize))
-    ) {
+    let limit = parseInt(this.config.get("share.maxSize"));
+    if (share.reverseShare?.maxShareSize) {
+      limit = parseInt(share.reverseShare.maxShareSize);
+    } else if (share.creator?.shareSizeLimit) {
+      limit = parseInt(share.creator.shareSizeLimit);
+    }
+
+    if (shareSizeSum > limit) {
       throw new HttpException(
         this.i18n.t("file.maxSizeExceeded"),
         HttpStatus.PAYLOAD_TOO_LARGE,

--- a/backend/src/reverseShare/dto/createReverseShare.dto.ts
+++ b/backend/src/reverseShare/dto/createReverseShare.dto.ts
@@ -1,10 +1,13 @@
-import { IsBoolean, IsString, Max, Min } from "class-validator";
+import { IsBoolean, IsString, Matches, Max, Min } from "class-validator";
 
 export class CreateReverseShareDTO {
   @IsBoolean()
   sendEmailNotification: boolean;
 
   @IsString()
+  @Matches(/^[0-9]+$/, {
+    message: "maxShareSize must contain only digits",
+  })
   maxShareSize: string;
 
   @IsString()

--- a/backend/src/reverseShare/reverseShare.service.ts
+++ b/backend/src/reverseShare/reverseShare.service.ts
@@ -37,12 +37,17 @@ export class ReverseShareService {
       throw new BadRequestException(this.i18n.t("share.maxExpirationExceeded"));
     }
 
-    const globalMaxShareSize = this.config.get("share.maxSize");
+    const creator = await this.prisma.user.findUnique({
+      where: { id: creatorId },
+    });
+    const userMaxShareSize = creator?.shareSizeLimit
+      ? parseInt(creator.shareSizeLimit)
+      : parseInt(this.config.get("share.maxSize"));
 
-    if (globalMaxShareSize < data.maxShareSize)
+    if (userMaxShareSize < parseInt(data.maxShareSize))
       throw new BadRequestException(
         this.i18n.t("reverseShare.maxShareSizeExceeded", {
-          args: { maxSize: globalMaxShareSize },
+          args: { maxSize: userMaxShareSize },
         }),
       );
 

--- a/backend/src/share/share.service.ts
+++ b/backend/src/share/share.service.ts
@@ -234,7 +234,7 @@ export class ShareService {
       orderBy: {
         expiration: "desc",
       },
-      include: { recipients: true, files: true, security: true },
+      include: { recipients: true, files: true, security: true, creator: true },
     });
 
     return shares.map((share) => this.transformShare(share));

--- a/backend/src/user/dto/publicUser.dto.ts
+++ b/backend/src/user/dto/publicUser.dto.ts
@@ -4,4 +4,5 @@ import { UserDTO } from "./user.dto";
 export class PublicUserDTO extends PickType(UserDTO, [
   "id",
   "username",
+  "shareSizeLimit",
 ] as const) {}

--- a/backend/src/user/dto/user.dto.ts
+++ b/backend/src/user/dto/user.dto.ts
@@ -1,5 +1,11 @@
 import { Expose, plainToClass } from "class-transformer";
-import { IsEmail, Length, Matches, MinLength } from "class-validator";
+import {
+  IsEmail,
+  IsOptional,
+  Length,
+  Matches,
+  MinLength,
+} from "class-validator";
 import { i18nValidationMessage } from "nestjs-i18n";
 
 export class UserDTO {
@@ -33,6 +39,13 @@ export class UserDTO {
   isLdap: boolean;
 
   ldapDN?: string;
+
+  @Expose()
+  @IsOptional()
+  @Matches(/^[0-9]+$/, {
+    message: "shareSizeLimit must contain only digits",
+  })
+  shareSizeLimit?: string;
 
   @Expose()
   totpVerified: boolean;

--- a/frontend/src/components/admin/users/showCreateUserModal.tsx
+++ b/frontend/src/components/admin/users/showCreateUserModal.tsx
@@ -13,6 +13,7 @@ import * as yup from "yup";
 import useTranslate from "../../../hooks/useTranslate.hook";
 import userService from "../../../services/user.service";
 import toast from "../../../utils/toast.util";
+import FileSizeInput from "../../core/FileSizeInput";
 
 const showCreateUserModal = (
   modals: ModalsContextProps,
@@ -44,6 +45,8 @@ const Body = ({
       password: undefined,
       isAdmin: false,
       setPasswordManually: false,
+      hasCustomShareSizeLimit: false,
+      shareSizeLimit: 104857600,
     },
     validate: yupResolver(
       yup.object().shape({
@@ -64,7 +67,15 @@ const Body = ({
       <form
         onSubmit={form.onSubmit(async (values) => {
           userService
-            .create(values)
+            .create({
+              username: values.username,
+              email: values.email,
+              password: values.password,
+              isAdmin: values.isAdmin,
+              shareSizeLimit: values.hasCustomShareSizeLimit
+                ? values.shareSizeLimit.toString()
+                : null,
+            })
             .then(() => {
               getUsers();
               modals.closeAll();
@@ -98,6 +109,30 @@ const Body = ({
             <PasswordInput
               label={t("admin.users.modal.create.password")}
               {...form.getInputProps("password")}
+            />
+          )}
+          <Switch
+            styles={{
+              body: {
+                display: "flex",
+                justifyContent: "space-between",
+              },
+            }}
+            mt="xs"
+            labelPosition="left"
+            label={t("admin.users.modal.create.custom-share-size-limit")}
+            description={t(
+              "admin.users.modal.create.custom-share-size-limit.description",
+            )}
+            {...form.getInputProps("hasCustomShareSizeLimit", {
+              type: "checkbox",
+            })}
+          />
+          {form.values.hasCustomShareSizeLimit && (
+            <FileSizeInput
+              label={t("admin.users.modal.create.custom-share-size-limit")}
+              value={form.values.shareSizeLimit}
+              onChange={(val) => form.setFieldValue("shareSizeLimit", val)}
             />
           )}
           <Switch

--- a/frontend/src/components/admin/users/showUpdateUserModal.tsx
+++ b/frontend/src/components/admin/users/showUpdateUserModal.tsx
@@ -17,6 +17,7 @@ import useTranslate, {
 import userService from "../../../services/user.service";
 import User from "../../../types/user.type";
 import toast from "../../../utils/toast.util";
+import FileSizeInput from "../../core/FileSizeInput";
 
 const showUpdateUserModal = (
   modals: ModalsContextProps,
@@ -47,6 +48,10 @@ const Body = ({
       email: user.email,
       isAdmin: user.isAdmin,
       isActivated: user.isActivated,
+      hasCustomShareSizeLimit: !!user.shareSizeLimit,
+      shareSizeLimit: user.shareSizeLimit
+        ? parseInt(user.shareSizeLimit)
+        : 104857600,
     },
     validate: yupResolver(
       yup.object().shape({
@@ -77,7 +82,15 @@ const Body = ({
         id="accountForm"
         onSubmit={accountForm.onSubmit(async (values) => {
           userService
-            .update(user.id, values)
+            .update(user.id, {
+              username: values.username,
+              email: values.email,
+              isAdmin: values.isAdmin,
+              isActivated: values.isActivated,
+              shareSizeLimit: values.hasCustomShareSizeLimit
+                ? values.shareSizeLimit.toString()
+                : null,
+            })
             .then(() => {
               getUsers();
               modals.closeAll();
@@ -107,6 +120,32 @@ const Body = ({
             {...accountForm.getInputProps("isActivated", { type: "checkbox" })}
             disabled={user.isActivated}
           />
+          <Switch
+            styles={{
+              body: {
+                display: "flex",
+                justifyContent: "space-between",
+              },
+            }}
+            mt="xs"
+            labelPosition="left"
+            label={t("admin.users.edit.update.custom-share-size-limit")}
+            description={t(
+              "admin.users.edit.update.custom-share-size-limit.description",
+            )}
+            {...accountForm.getInputProps("hasCustomShareSizeLimit", {
+              type: "checkbox",
+            })}
+          />
+          {accountForm.values.hasCustomShareSizeLimit && (
+            <FileSizeInput
+              label={t("admin.users.edit.update.custom-share-size-limit")}
+              value={accountForm.values.shareSizeLimit}
+              onChange={(val) =>
+                accountForm.setFieldValue("shareSizeLimit", val)
+              }
+            />
+          )}
         </Stack>
       </form>
       <Accordion>

--- a/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
+++ b/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
@@ -19,9 +19,12 @@ import * as yup from "yup";
 import useTranslate, {
   translateOutsideContext,
 } from "../../../hooks/useTranslate.hook";
+import useConfig from "../../../hooks/config.hook";
+import useUser from "../../../hooks/user.hook";
 import shareService from "../../../services/share.service";
 import { Timespan } from "../../../types/timespan.type";
 import { getExpirationPreview } from "../../../utils/date.util";
+import { byteToHumanSizeString } from "../../../utils/fileSize.util";
 import toast from "../../../utils/toast.util";
 import FileSizeInput from "../../core/FileSizeInput";
 import showCompletedReverseShareModal from "./showCompletedReverseShareModal";
@@ -69,6 +72,12 @@ const Body = ({
 }) => {
   const modals = useModals();
   const t = useTranslate();
+  const config = useConfig();
+  const { user } = useUser();
+
+  const userMaxShareSize = user?.shareSizeLimit
+    ? parseInt(user.shareSizeLimit)
+    : parseInt(config.get("share.maxSize"));
 
   const defaultTimespan = defaultExpiration
     ? defaultExpiration
@@ -76,7 +85,7 @@ const Body = ({
 
   const form = useForm({
     initialValues: {
-      maxShareSize: 104857600,
+      maxShareSize: Math.min(104857600, userMaxShareSize),
       maxUseCount: 1,
       sendEmailNotification: false,
       expiration_num: defaultTimespan.value,
@@ -91,6 +100,16 @@ const Body = ({
           .typeError(t("common.error.invalid-number"))
           .min(1, t("common.error.number-too-small", { min: 1 }))
           .max(1000, t("common.error.number-too-large", { max: 1000 }))
+          .required(t("common.error.field-required")),
+        maxShareSize: yup
+          .number()
+          .typeError(t("common.error.invalid-number"))
+          .max(
+            userMaxShareSize,
+            t("upload.dropzone.notify.file-too-big", {
+              maxSize: byteToHumanSizeString(userMaxShareSize),
+            }),
+          )
           .required(t("common.error.field-required")),
       }),
     ),

--- a/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
+++ b/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
@@ -19,8 +19,6 @@ import * as yup from "yup";
 import useTranslate, {
   translateOutsideContext,
 } from "../../../hooks/useTranslate.hook";
-import useConfig from "../../../hooks/config.hook";
-import useUser from "../../../hooks/user.hook";
 import shareService from "../../../services/share.service";
 import { Timespan } from "../../../types/timespan.type";
 import { getExpirationPreview } from "../../../utils/date.util";
@@ -36,6 +34,7 @@ const showCreateReverseShareModal = (
   defaultExpiration: Timespan,
   appUrl: string,
   defaultAppUrl: string,
+  maxShareSize: number,
   getReverseShares: () => void,
 ) => {
   const t = translateOutsideContext();
@@ -50,6 +49,7 @@ const showCreateReverseShareModal = (
         defaultExpiration={defaultExpiration}
         appUrl={appUrl}
         defaultAppUrl={defaultAppUrl}
+        maxShareSize={maxShareSize}
       />
     ),
   });
@@ -62,6 +62,7 @@ const Body = ({
   defaultExpiration,
   appUrl,
   defaultAppUrl,
+  maxShareSize,
 }: {
   getReverseShares: () => void;
   showSendEmailNotificationOption: boolean;
@@ -69,15 +70,12 @@ const Body = ({
   defaultExpiration: Timespan;
   appUrl: string;
   defaultAppUrl: string;
+  maxShareSize: number;
 }) => {
   const modals = useModals();
   const t = useTranslate();
-  const config = useConfig();
-  const { user } = useUser();
 
-  const userMaxShareSize = user?.shareSizeLimit
-    ? parseInt(user.shareSizeLimit)
-    : parseInt(config.get("share.maxSize"));
+  const userMaxShareSize = maxShareSize;
 
   const defaultTimespan = defaultExpiration
     ? defaultExpiration
@@ -247,8 +245,7 @@ const Body = ({
           </div>
           <FileSizeInput
             label={t("account.reverseShares.modal.max-size.label")}
-            value={form.values.maxShareSize}
-            onChange={(number) => form.setFieldValue("maxShareSize", number)}
+            {...form.getInputProps("maxShareSize")}
           />
           <NumberInput
             min={1}

--- a/frontend/src/components/share/showShareInformationsModal.tsx
+++ b/frontend/src/components/share/showShareInformationsModal.tsx
@@ -84,9 +84,13 @@ const Body = ({
 
   const link = `${appUrl !== defaultAppUrl ? appUrl : window.location.origin}/s/${currentShare.id}`;
 
+  const resolvedMaxShareSize = currentShare.creator?.shareSizeLimit
+    ? parseInt(currentShare.creator.shareSizeLimit)
+    : maxShareSize;
+
   const formattedShareSize = byteToHumanSizeString(currentShare.size);
-  const formattedMaxShareSize = byteToHumanSizeString(maxShareSize);
-  const shareSizeProgress = (currentShare.size / maxShareSize) * 100;
+  const formattedMaxShareSize = byteToHumanSizeString(resolvedMaxShareSize);
+  const shareSizeProgress = (currentShare.size / resolvedMaxShareSize) * 100;
 
   const formattedCreatedAt = moment(currentShare.createdAt).format("LLL");
   const formattedExpiration =
@@ -159,7 +163,7 @@ const Body = ({
       </Text>
 
       <Flex align="center" justify="center">
-        {currentShare.size / maxShareSize < 0.1 && (
+        {currentShare.size / resolvedMaxShareSize < 0.1 && (
           <Text size="xs" style={{ marginRight: "4px" }}>
             {formattedShareSize}
           </Text>
@@ -167,10 +171,13 @@ const Body = ({
         <Progress
           value={shareSizeProgress}
           label={
-            currentShare.size / maxShareSize >= 0.1 ? formattedShareSize : ""
+            currentShare.size / resolvedMaxShareSize >= 0.1
+              ? formattedShareSize
+              : ""
           }
           style={{
-            width: currentShare.size / maxShareSize < 0.1 ? "70%" : "80%",
+            width:
+              currentShare.size / resolvedMaxShareSize < 0.1 ? "70%" : "80%",
           }}
           size="xl"
           radius="xl"

--- a/frontend/src/components/share/showShareInformationsModal.tsx
+++ b/frontend/src/components/share/showShareInformationsModal.tsx
@@ -88,9 +88,13 @@ const Body = ({
     ? parseInt(currentShare.creator.shareSizeLimit)
     : maxShareSize;
 
+  const shareSizeRatio = resolvedMaxShareSize > 0
+    ? currentShare.size / resolvedMaxShareSize
+    : 0;
+
   const formattedShareSize = byteToHumanSizeString(currentShare.size);
   const formattedMaxShareSize = byteToHumanSizeString(resolvedMaxShareSize);
-  const shareSizeProgress = (currentShare.size / resolvedMaxShareSize) * 100;
+  const shareSizeProgress = shareSizeRatio * 100;
 
   const formattedCreatedAt = moment(currentShare.createdAt).format("LLL");
   const formattedExpiration =
@@ -163,7 +167,7 @@ const Body = ({
       </Text>
 
       <Flex align="center" justify="center">
-        {currentShare.size / resolvedMaxShareSize < 0.1 && (
+        {shareSizeRatio < 0.1 && (
           <Text size="xs" style={{ marginRight: "4px" }}>
             {formattedShareSize}
           </Text>
@@ -171,13 +175,13 @@ const Body = ({
         <Progress
           value={shareSizeProgress}
           label={
-            currentShare.size / resolvedMaxShareSize >= 0.1
+            shareSizeRatio >= 0.1
               ? formattedShareSize
               : ""
           }
           style={{
             width:
-              currentShare.size / resolvedMaxShareSize < 0.1 ? "70%" : "80%",
+              shareSizeRatio < 0.1 ? "70%" : "80%",
           }}
           size="xl"
           radius="xl"

--- a/frontend/src/components/upload/Dropzone.tsx
+++ b/frontend/src/components/upload/Dropzone.tsx
@@ -36,11 +36,13 @@ const Dropzone = ({
   title,
   isUploading,
   maxShareSize,
+  currentFilesSize = 0,
   onFilesChanged,
 }: {
   title?: string;
   isUploading: boolean;
   maxShareSize: number;
+  currentFilesSize?: number;
   onFilesChanged: (files: FileUpload[]) => void;
 }) => {
   const t = useTranslate();
@@ -58,7 +60,7 @@ const Dropzone = ({
         onDrop={(files: FileUpload[]) => {
           const fileSizeSum = files.reduce((n, { size }) => n + size, 0);
 
-          if (fileSizeSum > maxShareSize) {
+          if (fileSizeSum + currentFilesSize > maxShareSize) {
             toast.error(
               t("upload.dropzone.notify.file-too-big", {
                 maxSize: byteToHumanSizeString(maxShareSize),

--- a/frontend/src/components/upload/EditableUpload.tsx
+++ b/frontend/src/components/upload/EditableUpload.tsx
@@ -65,6 +65,15 @@ const EditableUpload = ({
     ? parseInt(user.shareSizeLimit)
     : parseInt(config.get("share.maxSize"));
 
+  const currentFilesSize = useMemo(() => {
+    return (
+      existingFiles
+        .filter((file) => !file.deleted)
+        .reduce((acc, file) => acc + parseInt(file.size), 0) +
+      uploadingFiles.reduce((acc, file) => acc + file.size, 0)
+    );
+  }, [existingFiles, uploadingFiles]);
+
   const uploadFiles = async (files: FileUpload[]) => {
     const fileUploadPromises = files.map(async (file, fileIndex) =>
       // Limit the number of concurrent uploads to 3
@@ -221,6 +230,7 @@ const EditableUpload = ({
       <Dropzone
         title={t("share.edit.append-upload")}
         maxShareSize={maxShareSize}
+        currentFilesSize={currentFilesSize}
         onFilesChanged={appendFiles}
         isUploading={isUploading}
       />

--- a/frontend/src/components/upload/EditableUpload.tsx
+++ b/frontend/src/components/upload/EditableUpload.tsx
@@ -9,6 +9,7 @@ import Dropzone from "../../components/upload/Dropzone";
 import FileList from "../../components/upload/FileList";
 import useConfig from "../../hooks/config.hook";
 import useTranslate from "../../hooks/useTranslate.hook";
+import useUser from "../../hooks/user.hook";
 import shareService from "../../services/share.service";
 import { FileListItem, FileMetaData, FileUpload } from "../../types/File.type";
 import toast from "../../utils/toast.util";
@@ -29,6 +30,7 @@ const EditableUpload = ({
   const t = useTranslate();
   const router = useRouter();
   const config = useConfig();
+  const { user } = useUser();
 
   const chunkSize = useRef(parseInt(config.get("share.chunkSize")));
 
@@ -59,7 +61,9 @@ const EditableUpload = ({
     setExistingFiles(_existingFiles);
   };
 
-  maxShareSize ??= parseInt(config.get("share.maxSize"));
+  maxShareSize ??= user?.shareSizeLimit
+    ? parseInt(user.shareSizeLimit)
+    : parseInt(config.get("share.maxSize"));
 
   const uploadFiles = async (files: FileUpload[]) => {
     const fileUploadPromises = files.map(async (file, fileIndex) =>

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -268,6 +268,9 @@ export default {
   "admin.users.edit.update.title": "Edit user: {username}",
   "admin.users.edit.update.admin-privileges": "Admin privileges",
   "admin.users.edit.update.email-verified": "Email verified",
+  "admin.users.edit.update.custom-share-size-limit": "Custom share size limit",
+  "admin.users.edit.update.custom-share-size-limit.description":
+    "Override the global upload limit for this user",
   "admin.users.edit.update.change-password.title": "Change password",
   "admin.users.edit.update.change-password.field": "New password",
   "admin.users.edit.update.change-password.button": "Save new password",
@@ -286,6 +289,9 @@ export default {
   "admin.users.modal.create.manual-password": "Set password manually",
   "admin.users.modal.create.manual-password.description":
     "If not checked, the user will receive an email with a link to set their password.",
+  "admin.users.modal.create.custom-share-size-limit": "Custom share size limit",
+  "admin.users.modal.create.custom-share-size-limit.description":
+    "Override the global upload limit for this user",
   "admin.users.modal.create.admin": "Admin privileges",
   "admin.users.modal.create.admin.description":
     "If checked, the user will be able to access the admin panel.",

--- a/frontend/src/pages/account/reverseShares.tsx
+++ b/frontend/src/pages/account/reverseShares.tsx
@@ -24,6 +24,7 @@ import { HoverTip } from "../../components/core/HoverTip";
 import CenterLoader from "../../components/core/CenterLoader";
 import showCreateReverseShareModal from "../../components/share/modals/showCreateReverseShareModal";
 import useConfig from "../../hooks/config.hook";
+import useUser from "../../hooks/user.hook";
 import useTranslate from "../../hooks/useTranslate.hook";
 import shareService from "../../services/share.service";
 import { MyReverseShare } from "../../types/share.type";
@@ -36,8 +37,13 @@ const MyShares = () => {
   const t = useTranslate();
 
   const config = useConfig();
+  const { user } = useUser();
   const appUrl = config.get("general.appUrl");
   const defaultAppUrl = config.get("general.appUrl", true);
+
+  const userMaxShareSize = user?.shareSizeLimit
+    ? parseInt(user.shareSizeLimit)
+    : parseInt(config.get("share.maxSize"));
 
   const [reverseShares, setReverseShares] = useState<MyReverseShare[]>();
 
@@ -75,6 +81,7 @@ const MyShares = () => {
               config.get("share.defaultExpiration"),
               appUrl,
               defaultAppUrl,
+              userMaxShareSize,
               getReverseShares,
             )
           }

--- a/frontend/src/pages/share/[shareId]/edit.tsx
+++ b/frontend/src/pages/share/[shareId]/edit.tsx
@@ -70,7 +70,15 @@ const Share = ({ shareId }: { shareId: string }) => {
   return (
     <>
       <Meta title={t("share.edit.title", { shareId })} />
-      <EditableUpload shareId={shareId} files={share?.files || []} />
+      <EditableUpload
+        shareId={shareId}
+        files={share?.files || []}
+        maxShareSize={
+          share?.creator?.shareSizeLimit
+            ? parseInt(share.creator.shareSizeLimit)
+            : undefined
+        }
+      />
     </>
   );
 };

--- a/frontend/src/pages/upload/index.tsx
+++ b/frontend/src/pages/upload/index.tsx
@@ -49,7 +49,9 @@ const Upload = ({
 
   const chunkSize = useRef(parseInt(config.get("share.chunkSize")));
 
-  maxShareSize ??= parseInt(config.get("share.maxSize"));
+  maxShareSize ??= user?.shareSizeLimit
+    ? parseInt(user.shareSizeLimit)
+    : parseInt(config.get("share.maxSize"));
   const autoOpenCreateUploadModal = config.get("share.autoOpenShareModal");
 
   const uploadFiles = async (share: CreateShare, files: FileUpload[]) => {

--- a/frontend/src/pages/upload/index.tsx
+++ b/frontend/src/pages/upload/index.tsx
@@ -3,7 +3,7 @@ import { useModals } from "@mantine/modals";
 import { cleanNotifications } from "@mantine/notifications";
 import { AxiosError } from "axios";
 import pLimit from "p-limit";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import Meta from "../../components/Meta";
 import Dropzone from "../../components/upload/Dropzone";
@@ -52,6 +52,11 @@ const Upload = ({
   maxShareSize ??= user?.shareSizeLimit
     ? parseInt(user.shareSizeLimit)
     : parseInt(config.get("share.maxSize"));
+
+  const currentFilesSize = useMemo(() => {
+    return files.reduce((acc, file) => acc + file.size, 0);
+  }, [files]);
+
   const autoOpenCreateUploadModal = config.get("share.autoOpenShareModal");
 
   const uploadFiles = async (share: CreateShare, files: FileUpload[]) => {
@@ -279,6 +284,7 @@ const Upload = ({
             : undefined
         }
         maxShareSize={maxShareSize}
+        currentFilesSize={currentFilesSize}
         onFilesChanged={handleDropzoneFilesChanged}
         isUploading={isUploading}
       />

--- a/frontend/src/types/user.type.ts
+++ b/frontend/src/types/user.type.ts
@@ -7,6 +7,7 @@ type User = {
   isLdap: boolean;
   totpVerified: boolean;
   hasPassword: boolean;
+  shareSizeLimit?: string;
 };
 
 export type CreateUser = {
@@ -14,6 +15,7 @@ export type CreateUser = {
   email: string;
   password?: string;
   isAdmin?: boolean;
+  shareSizeLimit?: string | null;
 };
 
 export type UpdateUser = {
@@ -22,6 +24,7 @@ export type UpdateUser = {
   password?: string;
   isAdmin?: boolean;
   isActivated?: boolean;
+  shareSizeLimit?: string | null;
 };
 
 export type UpdateCurrentUser = {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

GitHub Copilot was used for auto-complete. Gemini was used to review code and suggest manual testing.

## What's new?

- Admins can now set a share size limit individually in the "User Management" menu. 
  - If enabled, these limits will override the global default max share size limit. e.g. if the user's limit is higher than the global limit, the global limit can be exceeded by that user.
  - If a user is adding files to an existing share, their current limit is used to calculate max share size.


## How has it been tested?
- Created three users, two were given different maximum share sizes, one was left alone. Each user correctly showed their maximum share size and behaved as expected when trying to upload or create reverse shares.
- Tried creating a reverse share beyond a users max share size: error shown on the share size field.
- Tried appending files to an existing share, the users share size limit was respected.
- Changed user's share size limit, tried appending files to an existing share and was able to go up to the new limit.

## Screenshots
<img width="767" height="1024" alt="Image1" src="https://github.com/user-attachments/assets/087ff457-5f77-4e26-97fa-824f96e10fc1" />


Closes #95 
