### PR TITLE
feat(file): serve file downloads with HTTP Range support

### DIFF
--- a/backend/src/file/file.controller.ts
+++ b/backend/src/file/file.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  Headers,
   Param,
   Post,
   Query,
@@ -18,6 +19,7 @@ import { StrictShareOwnerGuard } from "src/share/guard/strictShareOwner.guard";
 import { IdValidation } from "src/share/guard/shareIdValidation.guard";
 import { FileService } from "./file.service";
 import { FileSecurityGuard } from "./guard/fileSecurity.guard";
+import { RangeNotSatisfiableError } from "./range";
 import * as mime from "mime-types";
 
 const VALID_ID_REGEX = /^[a-zA-Z0-9-]*={0,2}$/;
@@ -87,32 +89,60 @@ export class FileController {
     @Param("fileId") fileId: string,
     @Query("download") download = "true",
     @Query("recipient") recipientId?: string,
+    @Headers("range") rangeHeader?: string,
   ) {
-    const file = await this.fileService.get(shareId, fileId);
     const isDownload = download === "true";
 
-    const headers = {
-      "Content-Type":
-        mime?.lookup?.(file.metaData.name) || "application/octet-stream",
-      "Content-Length": file.metaData.size,
-      "Content-Security-Policy": "sandbox",
-      "Content-Disposition": contentDisposition(
-        file.metaData.name,
-        isDownload ? undefined : { type: "inline" },
-      ),
-    };
+    try {
+      const file = await this.fileService.get(shareId, fileId, rangeHeader);
 
-    res.set(headers);
+      const headers: Record<string, string> = {
+        "Content-Type":
+          mime?.lookup?.(file.metaData.name) || "application/octet-stream",
+        "Content-Length": file.metaData.size,
+        // Advertise range support so players know they can seek even before
+        // they issue a range request.
+        "Accept-Ranges": "bytes",
+        "Content-Security-Policy": "sandbox",
+        "Content-Disposition": contentDisposition(
+          file.metaData.name,
+          isDownload ? undefined : { type: "inline" },
+        ),
+      };
 
-    if (isDownload) {
-      void this.fileService.notifyRecipientDownload(
-        shareId,
-        file.metaData.name,
-        getValidRecipientId(recipientId),
-      );
+      // Partial content -> 206; override Content-Length with the served slice
+      // and add Content-Range so the browser can stream and seek instead of
+      // buffering the whole file first.
+      if (file.range) {
+        const { start, end, size } = file.range;
+        res.status(206);
+        headers["Content-Length"] = (end - start + 1).toString();
+        headers["Content-Range"] = `bytes ${start}-${end}/${size}`;
+      }
+
+      res.set(headers);
+
+      if (isDownload) {
+        void this.fileService.notifyRecipientDownload(
+          shareId,
+          file.metaData.name,
+          getValidRecipientId(recipientId),
+        );
+      }
+
+      return new StreamableFile(file.file);
+    } catch (e) {
+      // Valid Range we can't satisfy -> 416 with the total size.
+      if (e instanceof RangeNotSatisfiableError) {
+        res.status(416);
+        res.set({
+          "Accept-Ranges": "bytes",
+          "Content-Range": `bytes */${e.size}`,
+        });
+        return new StreamableFile(Buffer.alloc(0));
+      }
+      throw e;
     }
-
-    return new StreamableFile(file.file);
   }
 
   @Delete(":fileId")

--- a/backend/src/file/file.service.ts
+++ b/backend/src/file/file.service.ts
@@ -68,12 +68,16 @@ export class FileService {
     });
   }
 
-  async get(shareId: string, fileId: string): Promise<File> {
+  async get(
+    shareId: string,
+    fileId: string,
+    rangeHeader?: string,
+  ): Promise<File> {
     const share = await this.prisma.share.findFirst({
       where: { id: shareId },
     });
     const storageService = this.getStorageService(share.storageProvider);
-    return storageService.get(shareId, fileId);
+    return storageService.get(shareId, fileId, rangeHeader);
   }
 
   async remove(shareId: string, fileId: string) {
@@ -176,4 +180,11 @@ export interface File {
     shareId: string;
   };
   file: Readable;
+  // Set when the client sent a `Range` header and a partial body is being
+  // served. `start`/`end` are an inclusive byte range; `size` is the total
+  // file size. The controller turns this into a `206 Partial Content`
+  // response with the appropriate `Content-Range`/`Content-Length` headers.
+  // A valid-but-unservable range instead throws RangeNotSatisfiableError
+  // (see ./range), which the controller catches to answer `416`.
+  range?: { start: number; end: number; size: number };
 }

--- a/backend/src/file/local.service.ts
+++ b/backend/src/file/local.service.ts
@@ -16,6 +16,8 @@ import { PrismaService } from "src/prisma/prisma.service";
 import { validate as isValidUUID } from "uuid";
 import { SHARE_DIRECTORY } from "../constants";
 import { Readable } from "stream";
+import { File } from "./file.service";
+import { parseRangeHeader } from "./range";
 
 @Injectable()
 export class LocalFileService {
@@ -122,7 +124,7 @@ export class LocalFileService {
     return file;
   }
 
-  async get(shareId: string, fileId: string) {
+  async get(shareId: string, fileId: string, rangeHeader?: string) {
     const fileMetaData = await this.prisma.file.findUnique({
       where: { id: fileId },
     });
@@ -130,9 +132,25 @@ export class LocalFileService {
     if (!fileMetaData)
       throw new NotFoundException(this.i18n.t("file.notFound"));
 
-    const file = createReadStream(`${SHARE_DIRECTORY}/${shareId}/${fileId}`);
+    const path = `${SHARE_DIRECTORY}/${shareId}/${fileId}`;
 
-    return {
+    // Throws RangeNotSatisfiableError for a valid-but-unservable range; the
+    // controller catches that and answers 416.
+    const totalSize = parseInt(fileMetaData.size, 10);
+    const parsedRange = rangeHeader
+      ? parseRangeHeader(rangeHeader, totalSize)
+      : null;
+
+    // A satisfiable range streams just the requested slice, enabling seeking
+    // and play-before-fully-downloaded in browser <video>/<audio> players.
+    const file = createReadStream(
+      path,
+      parsedRange
+        ? { start: parsedRange.start, end: parsedRange.end }
+        : undefined,
+    );
+
+    const retVal: File = {
       metaData: {
         mimeType: mime.contentType(fileMetaData.name.split(".").pop()),
         ...fileMetaData,
@@ -140,6 +158,12 @@ export class LocalFileService {
       },
       file,
     };
+
+    if (parsedRange) {
+      retVal.range = { ...parsedRange, size: totalSize };
+    }
+
+    return retVal;
   }
 
   async remove(shareId: string, fileId: string) {

--- a/backend/src/file/range.ts
+++ b/backend/src/file/range.ts
@@ -1,0 +1,49 @@
+/**
+ * Thrown when the client sent a syntactically valid `Range` that cannot be
+ * served (RFC 7233 "416 Range Not Satisfiable"). Carries the resource's total
+ * size so the controller can report it in the 416 `Content-Range` header.
+ */
+export class RangeNotSatisfiableError extends Error {
+  constructor(public readonly size: number) {
+    super("Range not satisfiable");
+    this.name = "RangeNotSatisfiableError";
+  }
+}
+
+/**
+ * Parse a single-range HTTP `Range` header (RFC 7233) against a known total
+ * size. Returns an inclusive `{ start, end }` byte range, or `null` when the
+ * header is absent/malformed/multi-range, in which case the caller should fall
+ * back to serving the whole file. Throws `RangeNotSatisfiableError` when the
+ * range is valid syntax but cannot be served. Browsers only ever send a single
+ * range for media playback, so multi-range support is intentionally omitted.
+ */
+export function parseRangeHeader(
+  header: string,
+  size: number,
+): { start: number; end: number } | null {
+  const match = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
+  if (!match) return null;
+
+  const [, startStr, endStr] = match;
+  if (startStr === "" && endStr === "") return null;
+
+  let start: number;
+  let end: number;
+
+  if (startStr === "") {
+    // Suffix range: the final `endStr` bytes of the file.
+    const suffixLength = parseInt(endStr, 10);
+    if (suffixLength === 0) throw new RangeNotSatisfiableError(size);
+    start = Math.max(size - suffixLength, 0);
+    end = size - 1;
+  } else {
+    start = parseInt(startStr, 10);
+    end = endStr === "" ? size - 1 : parseInt(endStr, 10);
+    // Clamp an over-long end to the last byte, as permitted by the spec.
+    if (end > size - 1) end = size - 1;
+  }
+
+  if (start > end || start >= size) throw new RangeNotSatisfiableError(size);
+  return { start, end };
+}

--- a/backend/src/file/s3.service.ts
+++ b/backend/src/file/s3.service.ts
@@ -25,6 +25,7 @@ import * as crypto from "crypto";
 import * as mime from "mime-types";
 import { File } from "./file.service";
 import { Readable } from "stream";
+import { RangeNotSatisfiableError } from "./range";
 import { validate as isValidUUID } from "uuid";
 import * as archiver from "archiver";
 
@@ -168,33 +169,59 @@ export class S3FileService {
     return file;
   }
 
-  async get(shareId: string, fileId: string): Promise<File> {
+  async get(
+    shareId: string,
+    fileId: string,
+    rangeHeader?: string,
+  ): Promise<File> {
     const fileName = (
       await this.prisma.file.findUnique({ where: { id: fileId } })
     ).name;
 
     const s3Instance = this.getS3Instance();
     const key = `${this.getS3Path()}${shareId}/${fileName}`;
-    const response = await s3Instance.send(
-      new GetObjectCommand({
-        Bucket: this.config.get("s3.bucketName"),
-        Key: key,
-      }),
-    );
 
-    return {
-      metaData: {
-        id: fileId,
-        size: response.ContentLength?.toString() || "0",
-        name: fileName,
-        shareId: shareId,
-        createdAt: response.LastModified || new Date(),
-        mimeType:
-          mime.contentType(fileId.split(".").pop()) ||
-          "application/octet-stream",
-      },
-      file: response.Body as Readable,
-    } as File;
+    try {
+      const response = await s3Instance.send(
+        new GetObjectCommand({
+          Bucket: this.config.get("s3.bucketName"),
+          Key: key,
+          // S3 honours the same `Range` header semantics, replying 206 with a
+          // `ContentRange` we mirror to the client below.
+          Range: rangeHeader || undefined,
+        }),
+      );
+
+      // `ContentRange` ("bytes start-end/total") is only present on a 206.
+      const parsedRange = parseContentRange(response.ContentRange);
+
+      return {
+        metaData: {
+          id: fileId,
+          size:
+            (parsedRange?.size ?? response.ContentLength)?.toString() || "0",
+          name: fileName,
+          shareId: shareId,
+          createdAt: response.LastModified || new Date(),
+          mimeType:
+            mime.contentType(fileId.split(".").pop()) ||
+            "application/octet-stream",
+        },
+        file: response.Body as Readable,
+        ...(parsedRange ? { range: parsedRange } : {}),
+      } as File;
+    } catch (e) {
+      // S3 raises InvalidRange when the requested range can't be served; map it
+      // to the same RangeNotSatisfiableError the local backend throws (-> 416).
+      if (
+        rangeHeader &&
+        (e?.name === "InvalidRange" || e?.Code === "InvalidRange")
+      ) {
+        const total = await this.getFileSize(shareId, fileName);
+        throw new RangeNotSatisfiableError(total);
+      }
+      throw e;
+    }
   }
 
   async remove(shareId: string, fileId: string) {
@@ -380,4 +407,21 @@ export class S3FileService {
     const normalized = `${configS3Path}`.replace(/^\/+|\/+$/g, "");
     return normalized ? `${normalized}/` : "";
   }
+}
+
+/**
+ * Parse an S3 `ContentRange` response header ("bytes start-end/total") into the
+ * inclusive byte range plus total size, or `null` when absent/unparseable.
+ */
+function parseContentRange(
+  contentRange?: string,
+): { start: number; end: number; size: number } | null {
+  if (!contentRange) return null;
+  const match = /^bytes (\d+)-(\d+)\/(\d+)$/.exec(contentRange.trim());
+  if (!match) return null;
+  return {
+    start: parseInt(match[1], 10),
+    end: parseInt(match[2], 10),
+    size: parseInt(match[3], 10),
+  };
 }

--- a/backend/test/newman-system-tests.json
+++ b/backend/test/newman-system-tests.json
@@ -1090,6 +1090,104 @@
 							"response": []
 						},
 						{
+							"name": "Get File - Range",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 206\", () => {",
+											"    pm.response.to.have.status(206);",
+											"});",
+											"",
+											"pm.test(\"Partial content headers correct\", () => {",
+											"    pm.expect(pm.response.headers.get(\"Accept-Ranges\")).to.eql(\"bytes\");",
+											"    pm.expect(pm.response.headers.get(\"Content-Length\")).to.eql(\"1\");",
+											"    pm.expect(pm.response.headers.get(\"Content-Range\")).to.match(/^bytes 0-0\\/\\d+$/);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Range",
+										"value": "bytes=0-0"
+									}
+								],
+								"url": {
+									"raw": "{{API_URL}}/shares/:shareId/files/{{fileId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"shares",
+										":shareId",
+										"files",
+										"{{fileId}}"
+									],
+									"variable": [
+										{
+											"key": "shareId",
+											"value": "test-share"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get File - Range not satisfiable",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 416\", () => {",
+											"    pm.response.to.have.status(416);",
+											"});",
+											"",
+											"pm.test(\"Content-Range reports total size\", () => {",
+											"    pm.expect(pm.response.headers.get(\"Content-Range\")).to.match(/^bytes \\*\\/\\d+$/);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Range",
+										"value": "bytes=999999-"
+									}
+								],
+								"url": {
+									"raw": "{{API_URL}}/shares/:shareId/files/{{fileId}}",
+									"host": [
+										"{{API_URL}}"
+									],
+									"path": [
+										"shares",
+										":shareId",
+										"files",
+										"{{fileId}}"
+									],
+									"variable": [
+										{
+											"key": "shareId",
+											"value": "test-share"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "Get Zip",
 							"event": [
 								{


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Feature
- [x] Tests

## AI Usage

Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes

**Disclosure:** the code in this PR was **written by Claude (Anthropic's Claude Code, model Opus)**, used as a pair-programming tool. I then **reviewed every line myself**, iterated on the design, ran the build/lint/formatter, and tested it end-to-end against my own instances (details below). I understand the change, I can explain and defend every line, and I take responsibility for it. The two commits are kept small to make review straightforward. Happy to adjust anything on request.

## Why

We run a public Pingvin Share instance partly to hand people links to **large videos** (multi-GB drone/phone footage) and let them **preview the video in the browser before downloading**. Today that doesn't really work: opening a video preview forces the browser to download the *entire* file before playback starts, and the scrubber can't seek. For a 3–4 GB clip that's a multi-minute wait just to glance at it.

The cause is that the file endpoint ignores the HTTP `Range` request header, so the browser's native `<video>` player can't stream or seek — it can only fetch the whole object. This PR makes large-video (and audio) previews behave the way users expect: start playing immediately and seek instantly.

This was also requested upstream in the original (now-archived) repository — [stonith404/pingvin-share#791](https://github.com/stonith404/pingvin-share/issues/791) ("Add support for http range requests"), which was closed as *not planned*.

## What's new?

Adds **HTTP `Range` request support** to the single-file view/download endpoint.

**Before:** the endpoint streamed the whole file with a `StreamableFile` and never inspected the `Range` header — no `Accept-Ranges`, no `206 Partial Content`. So a browser `<video>`/`<audio>` element had to download the entire file before playback and could not seek/scrub.

**After:** the endpoint parses `Range` and serves only the requested byte slice, so players stream and seek. The change spans the storage layer and the controller:

- **`range.ts` (new):** a small, dependency-free module with the single-range RFC 7233 parser (`bytes=start-end`, `bytes=start-`, `bytes=-suffix`; clamps an over-long end) and a `RangeNotSatisfiableError` that carries the total size. Easy to unit-test and shared by both storage backends + the controller.
- **Local storage (`local.service.ts`):** `createReadStream(path, { start, end })` for the requested slice.
- **S3 storage (`s3.service.ts`):** passes the `Range` straight to `GetObjectCommand` and mirrors S3's `Content-Range`; maps S3's `InvalidRange` to the same `RangeNotSatisfiableError`.
- **Controller (`file.controller.ts`):** returns `206` with `Content-Range`/`Content-Length` for a partial request, advertises `Accept-Ranges: bytes` on full responses too (so players know they can seek), and catches `RangeNotSatisfiableError` to return `416` with `Content-Range: bytes */<size>`.
- **`File` interface:** gains an optional `range` (set for partial responses). The unsatisfiable case is signalled by the thrown `RangeNotSatisfiableError` rather than a flag, so the controller — which already owns the HTTP status decisions — is the single place that maps it to `416`.

**No frontend change** is needed: the existing preview already uses a native `<video>`/`<audio>` element, which begins issuing range requests as soon as the server advertises support.

**Scope:** only single-range requests are handled (what browsers send for media). Multi-range (`bytes=0-9,20-29`) is intentionally not implemented and falls back to serving the whole file.

## How has it been tested?

Static checks: `npm run build`, `eslint`, and prettier `--check` all pass.

**Local storage** — manually, end-to-end, against a live instance behind a reverse proxy, using a real 3.8 GB MP4:
- `Range: bytes=0-1023` → `HTTP 206`, `Content-Range: bytes 0-1023/3768210478`, `Content-Length: 1024`, `Accept-Ranges: bytes`.
- No `Range` → `HTTP 200` with `Accept-Ranges: bytes` and the full length.
- `Range: bytes=5000000000-` (past EOF) → `HTTP 416`, `Content-Range: bytes */3768210478`.
- In the browser, the video preview now starts immediately and the scrubber seeks, instead of downloading the whole file first.

**S3 storage** — end-to-end against a local MinIO (S3-compatible): multipart-uploaded a 15 MB file, then verified, with **byte-exact** payload comparisons:
- mid-file range and `bytes=-suffix` range → `206` with correct `Content-Range`;
- a full request → `200` with `Accept-Ranges`;
- an out-of-range request → `416` with `Content-Range: bytes */<size>`.
- This covers the `GetObject` Range pass-through, the `Content-Range` mirroring, and the `InvalidRange` → `416` mapping.

**System tests** — added two cases to the Newman collection (`backend/test/newman-system-tests.json`), next to the existing *Get File* request: a satisfiable `Range` → `206` (asserting `Content-Range`/`Accept-Ranges`/`Content-Length`) and an out-of-range `Range` → `416` (asserting `Content-Range: bytes */<size>`). The full suite passes via `npm run test:system` — 38 assertions, 0 failures.

## Screenshots

N/A
