### PR TITLE
fix(system): correctly detect disk usage on mounted filesystems (linux)

### DIFF
--- a/backend/src/system/system.service.ts
+++ b/backend/src/system/system.service.ts
@@ -16,7 +16,7 @@ export class SystemService {
       return null;
     }
 
-    const resolvedPath = path.resolve(DATA_DIRECTORY);
+    const resolvedPath = path.resolve(DATA_DIRECTORY, "uploads");
 
     try {
       const diskSpace = await checkDiskSpace(resolvedPath);


### PR DESCRIPTION
Changed the disk space check to target the `uploads` subdirectory instead of the entire data directory. This ensures that when uploads are stored on a separate mounted filesystem (e.g. an NFS share), the reported disk usage reflects the uploads filesystem rather than the parent data directory.

Partially fixes #122.

This has been verified on Ubuntu 22.04. Docker Desktop on macOS and Windows currently report the host filesystem due to platform-specific filesystem virtualization, which is outside the scope of this PR.

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage

Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

If you answer Yes and you have used AI in this submission disclose it here.
If you answer No and this PR appears to be fully or largely AI-generated, it will be closed by the maintainers.

**Disclosure:**

No AI was used to implement or fix this issue. It was a small change.

AI was only used to help understand parts of the codebase and troubleshoot some Docker/macOS permission issues during local testing.

## What's new?

- Changed the disk space check to use the `uploads` directory instead of the parent `data` directory.
- Correctly reports disk usage when uploads are stored on a separate mounted filesystem (e.g. NFS) on Linux.

## How has it been tested?

- Tested on Ubuntu 22.04 using Docker Compose.
- Verified with:
  - Local storage.
  - An NFS-mounted uploads directory.
- Confirmed that the reported disk usage matches the mounted filesystem.
- Tested on macOS with Docker Desktop. Docker Desktop reports the host filesystem instead of the underlying mounted share due to filesystem virtualization. This platform-specific behavior is not addressed by this PR.

## Screenshots

<img width="961" height="218" alt="image" src="https://github.com/user-attachments/assets/565ed674-6208-4649-a614-c2ca02c06c12" />
