### PR TITLE
fix(reverseShares): align max share size in modal with user/global settings

### DIFF
--- a/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
+++ b/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
@@ -87,7 +87,7 @@ const Body = ({
 
   const form = useForm({
     initialValues: {
-      maxShareSize: Math.min(104857600, userMaxShareSize),
+      maxShareSize: userMaxShareSize,
       maxUseCount: 1,
       sendEmailNotification: false,
       expiration_num: defaultTimespan.value,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

If you answer Yes and you have used AI in this submission disclose it here.
If you answer No and this PR that appears to be fully or largely AI-generated, it will be closed by the maintainers.

## What's new?

This fix ensures that the default max file size on the `/account/reverseShares` modal matches the user's actual settings (e.g., 30 GB) instead of defaulting to a hardcoded 100 MiB fallback.

This override is based on the `userMaxShareSize` variable, which is [always set](https://github.com/smp46/pingvin-share-x/blob/v1.21.0/frontend/src/pages/account/reverseShares.tsx#L44), removing the need for the hardcoded 100 MiB default.

## How has it been tested?
Tested manually on local selfhosted instance.

## Screenshots

<img width="791" height="321" alt="image" src="https://github.com/user-attachments/assets/c075b7f3-32d9-4921-b805-bc2f7480fa06" />

After the fix maximum reverse share file size is set to the settings value 30 GB and not 100 MiB as before:

<img width="453" height="494" alt="image" src="https://github.com/user-attachments/assets/1d6bab18-eeb5-4a5a-87ca-e757463f6226" />