### PR TITLE
feat: support folder uploads via drag'n'drop and selection

### DIFF
--- a/frontend/src/components/share/FileList.tsx
+++ b/frontend/src/components/share/FileList.tsx
@@ -24,6 +24,19 @@ import showFilePreviewModal from "./modals/showFilePreviewModal";
 import { HoverTip } from "../core/HoverTip";
 import api from "../../services/api.service";
 
+const renderFileName = (name: string) => {
+  const parts = name.split("/");
+  if (parts.length === 1) return name;
+  const fileName = parts.pop();
+  const folderPath = parts.join("/");
+  return (
+    <span>
+      <span style={{ opacity: 0.5 }}>{folderPath}/</span>
+      <strong>{fileName}</strong>
+    </span>
+  );
+};
+
 const FileList = ({
   files,
   setShare,
@@ -118,7 +131,7 @@ const FileList = ({
             ? skeletonRows
             : files!.map((file) => (
                 <tr key={file.name}>
-                  <td>{file.name}</td>
+                  <td>{renderFileName(file.name)}</td>
                   <td>{byteToHumanSizeString(parseInt(file.size))}</td>
                   <td>
                     <Group position="right" noWrap>

--- a/frontend/src/components/share/FileList.tsx
+++ b/frontend/src/components/share/FileList.tsx
@@ -32,7 +32,7 @@ const renderFileName = (name: string) => {
   return (
     <span>
       <span style={{ opacity: 0.5 }}>{folderPath}/</span>
-      <strong>{fileName}</strong>
+      <span style={{ fontWeight: 600 }}>{fileName}</span>
     </span>
   );
 };

--- a/frontend/src/components/upload/Dropzone.tsx
+++ b/frontend/src/components/upload/Dropzone.tsx
@@ -204,36 +204,19 @@ const Dropzone = ({
         </div>
       </MantineDropzone>
       <Center>
-        <Menu shadow="md" width={180} position="bottom">
-          <Menu.Target>
-            <Button
-              className={classes.control}
-              variant="light"
-              size="sm"
-              radius="xl"
-              disabled={isUploading}
-            >
-              <TbUpload style={{ marginRight: 6 }} />
-              <FormattedMessage id="upload.button.add" defaultMessage="Add to upload" />
-            </Button>
-          </Menu.Target>
-          <Menu.Dropdown>
-            <Menu.Item
-              icon={<TbUpload size={14} />}
-              onClick={() => openRef.current && openRef.current()}
-            >
-              <FormattedMessage id="upload.button.files" defaultMessage="Upload files" />
-            </Menu.Item>
-            {isFolderUploadSupported && (
-              <Menu.Item
-                icon={<TbFolder size={14} />}
-                onClick={() => folderInputRef.current?.click()}
-              >
-                <FormattedMessage id="upload.button.folder" defaultMessage="Upload folder" />
-              </Menu.Item>
-            )}
-          </Menu.Dropdown>
-        </Menu>
+        {isFolderUploadSupported && (
+          <Button
+            className={classes.control}
+            variant="light"
+            size="sm"
+            radius="xl"
+            disabled={isUploading}
+            onClick={() => folderInputRef.current?.click()}
+          >
+            <TbFolder style={{ marginRight: 6 }} />
+            <FormattedMessage id="upload.button.folder" defaultMessage="Upload folder" />
+          </Button>
+        )}
       </Center>
     </div>
   );

--- a/frontend/src/components/upload/Dropzone.tsx
+++ b/frontend/src/components/upload/Dropzone.tsx
@@ -1,7 +1,7 @@
-import { Button, Center, createStyles, Group, Text } from "@mantine/core";
+import { Button, Center, createStyles, Group, Text, Menu } from "@mantine/core";
 import { Dropzone as MantineDropzone } from "@mantine/dropzone";
-import { ForwardedRef, useRef } from "react";
-import { TbCloudUpload, TbUpload } from "react-icons/tb";
+import React, { ForwardedRef, useRef } from "react";
+import { TbCloudUpload, TbUpload, TbFolder } from "react-icons/tb";
 import { FormattedMessage } from "react-intl";
 import useTranslate from "../../hooks/useTranslate.hook";
 import { FileUpload } from "../../types/File.type";
@@ -32,6 +32,74 @@ const useStyles = createStyles((theme) => ({
   },
 }));
 
+const traverseDirectory = async (entry: any, path = ""): Promise<File[]> => {
+  if (entry.isFile) {
+    return new Promise((resolve) => {
+      entry.file((file: File) => {
+        const relativePath = path ? `${path}/${file.name}` : file.name;
+        Object.defineProperty(file, "webkitRelativePath", {
+          value: relativePath,
+          writable: true,
+          configurable: true,
+        });
+        resolve([file]);
+      });
+    });
+  } else if (entry.isDirectory) {
+    const dirReader = entry.createReader();
+    const readEntries = (): Promise<any[]> => {
+      return new Promise((resolve) => {
+        dirReader.readEntries(
+          (entries: any[]) => resolve(entries),
+          () => resolve([]),
+        );
+      });
+    };
+
+    let entries: any[] = [];
+    let readBatch = await readEntries();
+    while (readBatch.length > 0) {
+      entries = entries.concat(readBatch);
+      readBatch = await readEntries();
+    }
+
+    const promises = entries.map((e) =>
+      traverseDirectory(e, path ? `${path}/${entry.name}` : entry.name)
+    );
+    const results = await Promise.all(promises);
+    return results.flat();
+  }
+  return [];
+};
+
+const getFilesFromEvent = async (event: any): Promise<any[]> => {
+  const items = event.dataTransfer ? event.dataTransfer.items : event.target.files;
+  if (!items) return [];
+
+  const filePromises: Promise<File[]>[] = [];
+
+  if (event.dataTransfer) {
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (item.kind === "file") {
+        const entry = item.webkitGetAsEntry ? item.webkitGetAsEntry() : null;
+        if (entry) {
+          filePromises.push(traverseDirectory(entry));
+        } else {
+          const file = item.getAsFile();
+          if (file) {
+            filePromises.push(Promise.resolve([file]));
+          }
+        }
+      }
+    }
+    const fileArrays = await Promise.all(filePromises);
+    return fileArrays.flat();
+  } else {
+    return Array.from(items) as File[];
+  }
+};
+
 const Dropzone = ({
   title,
   isUploading,
@@ -46,17 +114,60 @@ const Dropzone = ({
   onFilesChanged: (files: FileUpload[]) => void;
 }) => {
   const t = useTranslate();
-
   const { classes } = useStyles();
   const openRef = useRef<() => void>();
+  const folderInputRef = useRef<HTMLInputElement>(null);
+
+  const isFolderUploadSupported =
+    typeof window !== "undefined" &&
+    typeof HTMLInputElement !== "undefined" &&
+    "webkitdirectory" in HTMLInputElement.prototype;
+
+  const handleFolderSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const filesList = event.target.files;
+    if (!filesList) return;
+    const filesArray = Array.from(filesList) as FileUpload[];
+
+    const files = filesArray.map((newFile) => {
+      newFile.uploadingProgress = 0;
+      return newFile;
+    });
+
+    const fileSizeSum = files.reduce((n, { size }) => n + size, 0);
+
+    if (fileSizeSum + currentFilesSize > maxShareSize) {
+      toast.error(
+        t("upload.dropzone.notify.file-too-big", {
+          maxSize: byteToHumanSizeString(maxShareSize),
+        }),
+      );
+    } else {
+      onFilesChanged(files);
+    }
+
+    event.target.value = "";
+  };
+
   return (
     <div className={classes.wrapper}>
+      <input
+        type="file"
+        ref={folderInputRef}
+        style={{ display: "none" }}
+        {...({
+          webkitdirectory: "",
+          directory: "",
+        } as any)}
+        multiple
+        onChange={handleFolderSelect}
+      />
       <MantineDropzone
         onReject={(e) => {
           toast.error(e[0].errors[0].message);
         }}
         disabled={isUploading}
         openRef={openRef as ForwardedRef<() => void>}
+        getFilesFromEvent={getFilesFromEvent}
         onDrop={(files: FileUpload[]) => {
           const fileSizeSum = files.reduce((n, { size }) => n + size, 0);
 
@@ -93,16 +204,36 @@ const Dropzone = ({
         </div>
       </MantineDropzone>
       <Center>
-        <Button
-          className={classes.control}
-          variant="light"
-          size="sm"
-          radius="xl"
-          disabled={isUploading}
-          onClick={() => openRef.current && openRef.current()}
-        >
-          {<TbUpload />}
-        </Button>
+        <Menu shadow="md" width={180} position="bottom">
+          <Menu.Target>
+            <Button
+              className={classes.control}
+              variant="light"
+              size="sm"
+              radius="xl"
+              disabled={isUploading}
+            >
+              <TbUpload style={{ marginRight: 6 }} />
+              <FormattedMessage id="upload.button.add" defaultMessage="Add to upload" />
+            </Button>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item
+              icon={<TbUpload size={14} />}
+              onClick={() => openRef.current && openRef.current()}
+            >
+              <FormattedMessage id="upload.button.files" defaultMessage="Upload files" />
+            </Menu.Item>
+            {isFolderUploadSupported && (
+              <Menu.Item
+                icon={<TbFolder size={14} />}
+                onClick={() => folderInputRef.current?.click()}
+              >
+                <FormattedMessage id="upload.button.folder" defaultMessage="Upload folder" />
+              </Menu.Item>
+            )}
+          </Menu.Dropdown>
+        </Menu>
       </Center>
     </div>
   );

--- a/frontend/src/components/upload/Dropzone.tsx
+++ b/frontend/src/components/upload/Dropzone.tsx
@@ -214,7 +214,9 @@ const Dropzone = ({
             onClick={() => folderInputRef.current?.click()}
           >
             <TbFolder style={{ marginRight: 6 }} />
-            <FormattedMessage id="upload.button.folder" defaultMessage="Upload folder" />
+            <FormattedMessage
+              id={currentFilesSize > 0 ? "upload.button.folder.append" : "upload.button.folder"}
+            />
           </Button>
         )}
       </Center>

--- a/frontend/src/components/upload/EditableUpload.tsx
+++ b/frontend/src/components/upload/EditableUpload.tsx
@@ -13,7 +13,7 @@ import useUser from "../../hooks/user.hook";
 import shareService from "../../services/share.service";
 import { FileListItem, FileMetaData, FileUpload } from "../../types/File.type";
 import toast from "../../utils/toast.util";
-import { getNormalizedFileName } from "../../utils/file.util";
+import { getNormalizedFileName, filterDuplicateFiles } from "../../utils/file.util";
 
 const promiseLimit = pLimit(3);
 let errorToastShown = false;
@@ -195,7 +195,14 @@ const EditableUpload = ({
   };
 
   const appendFiles = (appendingFiles: FileUpload[]) => {
-    setUploadingFiles([...appendingFiles, ...uploadingFiles]);
+    const combinedExisting = [...existingFiles, ...uploadingFiles];
+    const filtered = filterDuplicateFiles(
+      appendingFiles,
+      combinedExisting,
+      (normalizedName) => toast.error(t("upload.notify.duplicate-skipped", { name: normalizedName }))
+    );
+    if (filtered.length === 0) return;
+    setUploadingFiles([...filtered, ...uploadingFiles]);
   };
 
   useEffect(() => {

--- a/frontend/src/components/upload/EditableUpload.tsx
+++ b/frontend/src/components/upload/EditableUpload.tsx
@@ -13,14 +13,10 @@ import useUser from "../../hooks/user.hook";
 import shareService from "../../services/share.service";
 import { FileListItem, FileMetaData, FileUpload } from "../../types/File.type";
 import toast from "../../utils/toast.util";
+import { getNormalizedFileName } from "../../utils/file.util";
 
 const promiseLimit = pLimit(3);
 let errorToastShown = false;
-
-const getNormalizedFileName = (file: File): string => {
-  const pathName = file.webkitRelativePath || file.name;
-  return pathName.replace(/\\/g, "/").replace(/^\//, "");
-};
 
 const EditableUpload = ({
   maxShareSize,

--- a/frontend/src/components/upload/EditableUpload.tsx
+++ b/frontend/src/components/upload/EditableUpload.tsx
@@ -17,6 +17,11 @@ import toast from "../../utils/toast.util";
 const promiseLimit = pLimit(3);
 let errorToastShown = false;
 
+const getNormalizedFileName = (file: File): string => {
+  const pathName = file.webkitRelativePath || file.name;
+  return pathName.replace(/\\/g, "/").replace(/^\//, "");
+};
+
 const EditableUpload = ({
   maxShareSize,
   shareId,
@@ -109,7 +114,7 @@ const EditableUpload = ({
                 blob,
                 {
                   id: fileId,
-                  name: file.name,
+                  name: getNormalizedFileName(file),
                 },
                 chunkIndex,
                 chunks,

--- a/frontend/src/components/upload/FileList.tsx
+++ b/frontend/src/components/upload/FileList.tsx
@@ -11,6 +11,19 @@ import { HoverTip } from "../core/HoverTip";
 import showTextEditorModal from "./modals/showTextEditorModal";
 import shareService from "../../services/share.service";
 
+const renderFileName = (name: string) => {
+  const parts = name.split("/");
+  if (parts.length === 1) return name;
+  const fileName = parts.pop();
+  const folderPath = parts.join("/");
+  return (
+    <span>
+      <span style={{ opacity: 0.5 }}>{folderPath}/</span>
+      <strong>{fileName}</strong>
+    </span>
+  );
+};
+
 const FileListRow = ({
   file,
   onRemove,
@@ -43,7 +56,7 @@ const FileListRow = ({
           textDecoration: deleted ? "line-through" : "none",
         }}
       >
-        <td>{file.name}</td>
+        <td>{renderFileName(file.name)}</td>
         <td>{byteToHumanSizeString(+file.size)}</td>
         <td>
           <Group position="right" spacing="xs" noWrap>

--- a/frontend/src/components/upload/FileList.tsx
+++ b/frontend/src/components/upload/FileList.tsx
@@ -19,7 +19,7 @@ const renderFileName = (name: string) => {
   return (
     <span>
       <span style={{ opacity: 0.5 }}>{folderPath}/</span>
-      <strong>{fileName}</strong>
+      <span style={{ fontWeight: 600 }}>{fileName}</span>
     </span>
   );
 };

--- a/frontend/src/components/upload/FileList.tsx
+++ b/frontend/src/components/upload/FileList.tsx
@@ -24,6 +24,13 @@ const renderFileName = (name: string) => {
   );
 };
 
+const getFileNameOrPath = (file: FileListItem) => {
+  const pathName = ("webkitRelativePath" in file && file.webkitRelativePath)
+    ? file.webkitRelativePath
+    : file.name;
+  return pathName.replace(/\\/g, "/").replace(/^\//, "");
+};
+
 const FileListRow = ({
   file,
   onRemove,
@@ -44,7 +51,8 @@ const FileListRow = ({
     const restorable = onRestore && !uploadable && !!file.deleted;
     const deleted = !uploadable && !!file.deleted;
 
-    const isTextFile = shareService.isShareTextFile(file.name);
+    const fileNameOrPath = getFileNameOrPath(file);
+    const isTextFile = shareService.isShareTextFile(fileNameOrPath);
     const editable = isTextFile && uploadable && file.uploadingProgress === 0;
 
     const t = useTranslate();
@@ -56,7 +64,7 @@ const FileListRow = ({
           textDecoration: deleted ? "line-through" : "none",
         }}
       >
-        <td>{renderFileName(file.name)}</td>
+        <td>{renderFileName(fileNameOrPath)}</td>
         <td>{byteToHumanSizeString(+file.size)}</td>
         <td>
           <Group position="right" spacing="xs" noWrap>

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -332,6 +332,7 @@ export default {
   "upload.dropzone.notify.file-too-big":
     "Your files exceed the maximum share size of {maxSize}.",
   "upload.button.folder": "Upload folder",
+  "upload.button.folder.append": "Append folder",
   "upload.button.add": "Add to upload",
 
   // FileList.tsx

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -328,10 +328,9 @@ export default {
   // Dropzone.tsx
   "upload.dropzone.title": "Upload files",
   "upload.dropzone.description":
-    "Drag'n'drop files here to start your share or 'Ctrl+V' to upload text content from the clipboard. We only accept files up to {maxSize} in total.",
+    "Drag'n'drop files or folders here to start your share or 'Ctrl+V' to upload text content from the clipboard. We only accept files up to {maxSize} in total.",
   "upload.dropzone.notify.file-too-big":
     "Your files exceed the maximum share size of {maxSize}.",
-  "upload.button.files": "Upload files",
   "upload.button.folder": "Upload folder",
   "upload.button.add": "Add to upload",
 

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -331,6 +331,9 @@ export default {
     "Drag'n'drop files here to start your share or 'Ctrl+V' to upload text content from the clipboard. We only accept files up to {maxSize} in total.",
   "upload.dropzone.notify.file-too-big":
     "Your files exceed the maximum share size of {maxSize}.",
+  "upload.button.files": "Upload files",
+  "upload.button.folder": "Upload folder",
+  "upload.button.add": "Add to upload",
 
   // FileList.tsx
   "upload.filelist.name": "Name",

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -321,6 +321,7 @@ export default {
   "upload.notify.generic-error":
     "An error occurred while finishing your share.",
   "upload.notify.count-failed": "{count} files failed to upload. Trying again.",
+  "upload.notify.duplicate-skipped": "Skipped duplicate file: {name}",
   "upload.reverse-share.error.invalid.title": "Invalid reverse share link",
   "upload.reverse-share.error.invalid.description":
     "This link has no remaining uses or is invalid.",

--- a/frontend/src/pages/upload/index.tsx
+++ b/frontend/src/pages/upload/index.tsx
@@ -24,6 +24,11 @@ const promiseLimit = pLimit(3);
 let errorToastShown = false;
 let createdShare: Share;
 
+const getNormalizedFileName = (file: File): string => {
+  const pathName = file.webkitRelativePath || file.name;
+  return pathName.replace(/\\/g, "/").replace(/^\//, "");
+};
+
 const Upload = ({
   maxShareSize,
   isReverseShare = false,
@@ -109,7 +114,7 @@ const Upload = ({
                 blob,
                 {
                   id: fileId,
-                  name: file.name,
+                  name: getNormalizedFileName(file),
                 },
                 chunkIndex,
                 chunks,

--- a/frontend/src/pages/upload/index.tsx
+++ b/frontend/src/pages/upload/index.tsx
@@ -19,7 +19,7 @@ import { FileUpload } from "../../types/File.type";
 import { CreateShare, Share } from "../../types/share.type";
 import toast from "../../utils/toast.util";
 import { useRouter } from "next/router";
-import { getNormalizedFileName } from "../../utils/file.util";
+import { getNormalizedFileName, filterDuplicateFiles } from "../../utils/file.util";
 
 const promiseLimit = pLimit(3);
 let errorToastShown = false;
@@ -166,12 +166,19 @@ const Upload = ({
     );
   };
 
-  const handleDropzoneFilesChanged = (files: FileUpload[]) => {
+  const handleDropzoneFilesChanged = (newFiles: FileUpload[]) => {
+    const filtered = filterDuplicateFiles(
+      newFiles,
+      files,
+      (normalizedName) => toast.error(t("upload.notify.duplicate-skipped", { name: normalizedName }))
+    );
+    if (filtered.length === 0) return;
+
     if (autoOpenCreateUploadModal) {
-      setFiles(files);
-      showCreateUploadModalCallback(files);
+      setFiles(filtered);
+      showCreateUploadModalCallback(filtered);
     } else {
-      setFiles((oldArr) => [...oldArr, ...files]);
+      setFiles((oldArr) => [...oldArr, ...filtered]);
     }
   };
 
@@ -206,11 +213,18 @@ const Upload = ({
         const fileUpload = file as FileUpload;
         fileUpload.uploadingProgress = 0;
 
+        const filtered = filterDuplicateFiles(
+          [fileUpload],
+          files,
+          (normalizedName) => toast.error(t("upload.notify.duplicate-skipped", { name: normalizedName }))
+        );
+        if (filtered.length === 0) return;
+
         if (autoOpenCreateUploadModal) {
-          setFiles([fileUpload]);
-          showCreateUploadModalCallback([fileUpload]);
+          setFiles(filtered);
+          showCreateUploadModalCallback(filtered);
         } else {
-          setFiles((oldArr) => [...oldArr, fileUpload]);
+          setFiles((oldArr) => [...oldArr, ...filtered]);
         }
       }
     };

--- a/frontend/src/pages/upload/index.tsx
+++ b/frontend/src/pages/upload/index.tsx
@@ -19,15 +19,11 @@ import { FileUpload } from "../../types/File.type";
 import { CreateShare, Share } from "../../types/share.type";
 import toast from "../../utils/toast.util";
 import { useRouter } from "next/router";
+import { getNormalizedFileName } from "../../utils/file.util";
 
 const promiseLimit = pLimit(3);
 let errorToastShown = false;
 let createdShare: Share;
-
-const getNormalizedFileName = (file: File): string => {
-  const pathName = file.webkitRelativePath || file.name;
-  return pathName.replace(/\\/g, "/").replace(/^\//, "");
-};
 
 const Upload = ({
   maxShareSize,

--- a/frontend/src/utils/file.util.ts
+++ b/frontend/src/utils/file.util.ts
@@ -2,3 +2,32 @@ export const getNormalizedFileName = (file: File): string => {
   const pathName = file.webkitRelativePath || file.name;
   return pathName.replace(/\\/g, "/").replace(/^\//, "");
 };
+
+export const filterDuplicateFiles = <T extends File>(
+  newFiles: T[],
+  existingFilesList: Array<{ name: string; webkitRelativePath?: string; deleted?: boolean }>,
+  onDuplicateDetected: (name: string) => void
+): T[] => {
+  const existingNames = new Set(
+    existingFilesList
+      .filter((file) => !file.deleted)
+      .map((file) => {
+        const pathName = file.webkitRelativePath || file.name;
+        return pathName.replace(/\\/g, "/").replace(/^\//, "");
+      })
+  );
+
+  const filtered: T[] = [];
+  const seenInBatch = new Set<string>();
+
+  for (const file of newFiles) {
+    const normalizedName = getNormalizedFileName(file);
+    if (existingNames.has(normalizedName) || seenInBatch.has(normalizedName)) {
+      onDuplicateDetected(normalizedName);
+    } else {
+      seenInBatch.add(normalizedName);
+      filtered.push(file);
+    }
+  }
+  return filtered;
+};

--- a/frontend/src/utils/file.util.ts
+++ b/frontend/src/utils/file.util.ts
@@ -1,0 +1,4 @@
+export const getNormalizedFileName = (file: File): string => {
+  const pathName = file.webkitRelativePath || file.name;
+  return pathName.replace(/\\/g, "/").replace(/^\//, "");
+};


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

Gemini was used to find the best way to add folder upload functionality to the existing Mantine dropzone component.

## What's new?
- The upload page and edit share pages now support uploading folders via drag'n'drop and folder selection. 
  - This *should* only be an option if the browser supports the webkit APIs required for this.
  - Pathnames are now displayed for each file, with the folder name bolded for clarity.
  - Files downloaded individually won't be downloaded as a folder.
  - When using "Download all", downloading the whole share as a zip, the folder paths will be preserved.
  - Uploading files with a full path (folder and file name included) matching an existing file will be skipped and a toast notification will appear to indicate this.

## How has it been tested?
- Regular uploads with files work as expected.
- Using the "Upload folder" button correctly displays the OS specific folder upload dialogue.
- When uploading folders, paths are displayed both before and after creating the share.
- Duplicate files with matching folder name are skipped and a toast notification is shown for each file skipped.
- All of the above was tested again on existing shares, via the Add / Remove button.
- All of the above was also tested with S3 enabled and disabled.

## Screenshots
**Upload page:**
<img width="1024" height="418" alt="Imagepipe_7" src="https://github.com/user-attachments/assets/14a30af3-2c6b-47af-ad0e-cab4c135a64c" />

**Post-folder selection on upload page:**
<img width="1024" height="557" alt="Imagepipe_6" src="https://github.com/user-attachments/assets/d297e86c-3cca-41d0-a9f7-b06a6e33661d" />

**Existing share containing folders:**
<img width="1024" height="521" alt="Imagepipe_5" src="https://github.com/user-attachments/assets/8e637d3f-bab9-48df-a9f3-77faad92e4d8" />


Closes #116 
