### PR TITLE
feat(shares): allow admins to bypass max file expiration

### DIFF
--- a/backend/src/reverseShare/reverseShare.service.ts
+++ b/backend/src/reverseShare/reverseShare.service.ts
@@ -27,19 +27,20 @@ export class ReverseShareService {
       )
       .toDate();
 
+    const creator = await this.prisma.user.findUnique({
+      where: { id: creatorId },
+    });
+
     const parsedExpiration = parseRelativeDateToAbsolute(data.shareExpiration);
     const maxExpiration = this.config.get("share.maxExpiration");
     if (
+      !creator?.isAdmin &&
       maxExpiration.value !== 0 &&
       parsedExpiration >
         moment().add(maxExpiration.value, maxExpiration.unit).toDate()
     ) {
       throw new BadRequestException(this.i18n.t("share.maxExpirationExceeded"));
     }
-
-    const creator = await this.prisma.user.findUnique({
-      where: { id: creatorId },
-    });
     const userMaxShareSize = creator?.shareSizeLimit
       ? parseInt(creator.shareSizeLimit)
       : parseInt(this.config.get("share.maxSize"));

--- a/backend/src/share/share.service.ts
+++ b/backend/src/share/share.service.ts
@@ -66,7 +66,9 @@ export class ShareService {
       expirationDate = reverseShare.shareExpiration;
     } else {
       expirationDate = this.parseExpiration(share.expiration);
-      this.validateExpiration(expirationDate);
+      if (!user?.isAdmin) {
+        this.validateExpiration(expirationDate);
+      }
     }
 
     fs.mkdirSync(`${SHARE_DIRECTORY}/${share.id}`, {
@@ -328,7 +330,9 @@ export class ShareService {
     let expirationDate: Date | undefined;
     if (body.expiration !== undefined) {
       expirationDate = this.parseExpiration(body.expiration);
-      this.validateExpiration(expirationDate);
+      if (!user?.isAdmin) {
+        this.validateExpiration(expirationDate);
+      }
     }
 
     const data: Prisma.ShareUpdateInput = {

--- a/frontend/src/components/admin/shares/ManageShareTable.tsx
+++ b/frontend/src/components/admin/shares/ManageShareTable.tsx
@@ -124,7 +124,7 @@ const ManageShareTable = ({
                               parseInt(config.get("share.maxSize")),
                               config.get("general.appUrl"),
                               config.get("general.appUrl", true),
-                              config.get("share.maxExpiration"),
+                              { value: 0, unit: "days" },
                               updateShare,
                             );
                           }}

--- a/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
+++ b/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
@@ -83,7 +83,9 @@ const Body = ({
 
   const defaultTimespan = defaultExpiration
     ? defaultExpiration
-    : { value: 7, unit: "days" };
+    : maxExpiration && maxExpiration.value !== 0
+      ? maxExpiration
+      : { value: 7, unit: "days" };
 
   const form = useForm({
     initialValues: {
@@ -92,7 +94,9 @@ const Body = ({
       sendEmailNotification: false,
       expiration_num: defaultTimespan.value,
       expiration_unit: `-${defaultTimespan.unit}` as string,
-      simplified: !reverseShareSimpleOnly ? false : !!(getCookie("reverse-share.simplified") ?? false),
+      simplified: !reverseShareSimpleOnly
+        ? false
+        : !!(getCookie("reverse-share.simplified") ?? false),
       publicAccess: !!(getCookie("reverse-share.public-access") ?? true),
     },
     validate: yupResolver(
@@ -273,7 +277,7 @@ const Body = ({
               })}
             />
           )}
-          {!reverseShareSimpleOnly &&
+          {!reverseShareSimpleOnly && (
             <Switch
               mt="xs"
               labelPosition="left"
@@ -285,7 +289,7 @@ const Body = ({
                 type: "checkbox",
               })}
             />
-          }
+          )}
           <Switch
             mt="xs"
             labelPosition="left"
@@ -301,8 +305,8 @@ const Body = ({
             <FormattedMessage id="common.button.create" />
           </Button>
         </Stack>
-      </form >
-    </Group >
+      </form>
+    </Group>
   );
 };
 

--- a/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
+++ b/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
@@ -83,9 +83,7 @@ const Body = ({
 
   const defaultTimespan = defaultExpiration
     ? defaultExpiration
-    : maxExpiration && maxExpiration.value !== 0
-      ? maxExpiration
-      : { value: 7, unit: "days" };
+    : { value: 7, unit: "days" };
 
   const form = useForm({
     initialValues: {

--- a/frontend/src/components/share/showShareInformationsModal.tsx
+++ b/frontend/src/components/share/showShareInformationsModal.tsx
@@ -88,9 +88,8 @@ const Body = ({
     ? parseInt(currentShare.creator.shareSizeLimit)
     : maxShareSize;
 
-  const shareSizeRatio = resolvedMaxShareSize > 0
-    ? currentShare.size / resolvedMaxShareSize
-    : 0;
+  const shareSizeRatio =
+    resolvedMaxShareSize > 0 ? currentShare.size / resolvedMaxShareSize : 0;
 
   const formattedShareSize = byteToHumanSizeString(currentShare.size);
   const formattedMaxShareSize = byteToHumanSizeString(resolvedMaxShareSize);
@@ -174,14 +173,9 @@ const Body = ({
         )}
         <Progress
           value={shareSizeProgress}
-          label={
-            shareSizeRatio >= 0.1
-              ? formattedShareSize
-              : ""
-          }
+          label={shareSizeRatio >= 0.1 ? formattedShareSize : ""}
           style={{
-            width:
-              shareSizeRatio < 0.1 ? "70%" : "80%",
+            width: shareSizeRatio < 0.1 ? "70%" : "80%",
           }}
           size="xl"
           radius="xl"

--- a/frontend/src/components/upload/modals/showCreateUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCreateUploadModal.tsx
@@ -161,7 +161,9 @@ const CreateUploadModalBody = ({
 
   const defaultTimespan = options.defaultExpiration
     ? options.defaultExpiration
-    : { value: 7, unit: "days" };
+    : options.maxExpiration && options.maxExpiration.value !== 0
+      ? options.maxExpiration
+      : { value: 7, unit: "days" };
 
   const form = useForm({
     initialValues: {

--- a/frontend/src/components/upload/modals/showCreateUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCreateUploadModal.tsx
@@ -161,9 +161,7 @@ const CreateUploadModalBody = ({
 
   const defaultTimespan = options.defaultExpiration
     ? options.defaultExpiration
-    : options.maxExpiration && options.maxExpiration.value !== 0
-      ? options.maxExpiration
-      : { value: 7, unit: "days" };
+    : { value: 7, unit: "days" };
 
   const form = useForm({
     initialValues: {

--- a/frontend/src/pages/account/reverseShares.tsx
+++ b/frontend/src/pages/account/reverseShares.tsx
@@ -77,7 +77,9 @@ const MyShares = () => {
             showCreateReverseShareModal(
               modals,
               config.get("smtp.enabled"),
-              config.get("share.maxExpiration"),
+              user?.isAdmin
+                ? { value: 0, unit: "days" }
+                : config.get("share.maxExpiration"),
               config.get("share.defaultExpiration"),
               config.get("share.reverseShareSimpleOnly"),
               appUrl,

--- a/frontend/src/pages/account/shares.tsx
+++ b/frontend/src/pages/account/shares.tsx
@@ -29,6 +29,7 @@ import showShareLinkModal from "../../components/account/showShareLinkModal";
 import { HoverTip } from "../../components/core/HoverTip";
 import CenterLoader from "../../components/core/CenterLoader";
 import useConfig from "../../hooks/config.hook";
+import useUser from "../../hooks/user.hook";
 import useTranslate from "../../hooks/useTranslate.hook";
 import shareService from "../../services/share.service";
 import { MyShare } from "../../types/share.type";
@@ -38,6 +39,7 @@ const MyShares = () => {
   const modals = useModals();
   const clipboard = useClipboard();
   const config = useConfig();
+  const { user } = useUser();
   const t = useTranslate();
 
   const [shares, setShares] = useState<MyShare[]>();
@@ -145,7 +147,9 @@ const MyShares = () => {
                               parseInt(config.get("share.maxSize")),
                               config.get("general.appUrl"),
                               config.get("general.appUrl", true),
-                              config.get("share.maxExpiration"),
+                              user?.isAdmin
+                                ? { value: 0, unit: "days" }
+                                : config.get("share.maxExpiration"),
                               (updatedShare) =>
                                 setShares(
                                   shares.map((item) =>

--- a/frontend/src/pages/admin/intro.tsx
+++ b/frontend/src/pages/admin/intro.tsx
@@ -33,11 +33,8 @@ const Intro = () => {
             </Anchor>{" "}
           </Text>
           <Text>
-            You can also support development via {" "}
-            <Anchor
-              target="_blank"
-              href="https://github.com/sponsors/smp46"
-            >
+            You can also support development via{" "}
+            <Anchor target="_blank" href="https://github.com/sponsors/smp46">
               GitHub Sponsors ❤️
             </Anchor>{" "}
           </Text>

--- a/frontend/src/pages/auth/verify/[token].tsx
+++ b/frontend/src/pages/auth/verify/[token].tsx
@@ -49,27 +49,21 @@ export default function VerifyAccount() {
             {status === "success" && (
               <>
                 <Text align="center">
-                  <FormattedMessage
-                    id="verify.success"
-                  />
+                  <FormattedMessage id="verify.success" />
                 </Text>
                 <Button
                   fullWidth
                   mt="xl"
                   onClick={() => router.replace("/auth/signIn")}
                 >
-                  <FormattedMessage
-                    id="verify.button.signin"
-                  />
+                  <FormattedMessage id="verify.button.signin" />
                 </Button>
               </>
             )}
             {status === "error" && (
               <>
                 <Text align="center" color="red">
-                  <FormattedMessage
-                    id="verify.error"
-                  />
+                  <FormattedMessage id="verify.error" />
                 </Text>
                 <Button
                   fullWidth

--- a/frontend/src/pages/auth/verify/info.tsx
+++ b/frontend/src/pages/auth/verify/info.tsx
@@ -32,16 +32,12 @@ export default function VerificationInfo() {
       <Meta title={t("verify.info.title")} />
       <Container size={420} my={40}>
         <Title order={2} align="center" weight={900}>
-          <FormattedMessage
-            id="verify.info.title"
-          />
+          <FormattedMessage id="verify.info.title" />
         </Title>
         <Paper withBorder shadow="md" p={30} mt={30} radius="md">
           <Stack align="center">
             <Text align="center">
-              <FormattedMessage
-                id="verify.info.description"
-              />
+              <FormattedMessage id="verify.info.description" />
             </Text>
             {email && (
               <Text weight={700} size="sm">
@@ -49,9 +45,7 @@ export default function VerificationInfo() {
               </Text>
             )}
             <Text align="center" size="sm" color="dimmed">
-              <FormattedMessage
-                id="verify.info.note"
-              />
+              <FormattedMessage id="verify.info.note" />
             </Text>
             <Stack w="100%" mt="xl">
               <Button
@@ -61,14 +55,10 @@ export default function VerificationInfo() {
                 disabled={!email}
                 fullWidth
               >
-                <FormattedMessage
-                  id="verify.info.resend.button"
-                />
+                <FormattedMessage id="verify.info.resend.button" />
               </Button>
               <Button fullWidth onClick={() => router.replace("/auth/signIn")}>
-                <FormattedMessage
-                  id="verify.button.signin"
-                />
+                <FormattedMessage id="verify.button.signin" />
               </Button>
             </Stack>
           </Stack>

--- a/frontend/src/pages/share/[shareId]/index.tsx
+++ b/frontend/src/pages/share/[shareId]/index.tsx
@@ -53,7 +53,9 @@ const Share = ({ shareId }: { shareId: string }) => {
         parseInt(config.get("share.maxSize")),
         config.get("general.appUrl"),
         config.get("general.appUrl", true),
-        config.get("share.maxExpiration"),
+        user?.isAdmin
+          ? { value: 0, unit: "days" }
+          : config.get("share.maxExpiration"),
         (updatedShare: MyShare) => {
           setShare((prev) =>
             prev

--- a/frontend/src/pages/upload/index.tsx
+++ b/frontend/src/pages/upload/index.tsx
@@ -155,7 +155,9 @@ const Upload = ({
           "share.allowUnauthenticatedShares",
         ),
         enableEmailRecepients: config.get("email.enableShareEmailRecipients"),
-        maxExpiration: config.get("share.maxExpiration"),
+        maxExpiration: user?.isAdmin
+          ? { value: 0, unit: "days" }
+          : config.get("share.maxExpiration"),
         defaultExpiration: config.get("share.defaultExpiration"),
         shareIdLength: config.get("share.shareIdLength"),
         simplified,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [ ] Yes
- [x] No


## What's new?
- Max expiration is now not enforced when the admin is creating a share (regular or reverse share). Admins can always set expiry to anything (including never).

## How has it been tested?
- Set max expiry to 5 minutes as admin then:
  - as admin:
     - successfully created a share with a 6 minute expiry
     - successfully created a reverse share link with a 6 minute expiry
     - successfully edited own share to become permanent 
     - successfully edited another users share to become permanent 
   - as regular user:
     - can't create a share with a 6 minute expiry, the user gets the error: "Expiration date exceeds the maximum of 5 minutes."
     - can't create a reverse share link with a 6 minute expiry, same error as above.
     - can't edit own share beyond max expiry limit

Closes #111
