### PR TITLE
fix(i18n): show English text when a translation key is missing

### DIFF
--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -17,7 +17,7 @@ import { GetServerSidePropsContext } from "next";
 import type { AppProps } from "next/app";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { IntlProvider } from "react-intl";
 import Header from "../components/header/Header";
 import { ConfigContext } from "../hooks/config.hook";
@@ -252,6 +252,16 @@ function App({ Component, pageProps }: AppProps) {
   const language = useRef(pageProps.language);
   moment.locale(language.current);
 
+  // fall back to english for keys that are not translated yet,
+  // memoized so the intl provider isn't rebuilt on every render
+  const messages = useMemo(
+    () => ({
+      ...LOCALES.ENGLISH.messages,
+      ...i18nUtil.getLocaleByCode(language.current)?.messages,
+    }),
+    [],
+  );
+
   return (
     <>
       <Head>
@@ -261,11 +271,7 @@ function App({ Component, pageProps }: AppProps) {
         />
       </Head>
       <IntlProvider
-        messages={{
-          // fall back to english for keys that are not translated yet
-          ...LOCALES.ENGLISH.messages,
-          ...i18nUtil.getLocaleByCode(language.current)?.messages,
-        }}
+        messages={messages}
         locale={language.current}
         defaultLocale={LOCALES.ENGLISH.code}
       >

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -261,7 +261,11 @@ function App({ Component, pageProps }: AppProps) {
         />
       </Head>
       <IntlProvider
-        messages={i18nUtil.getLocaleByCode(language.current)?.messages}
+        messages={{
+          // fall back to english for keys that are not translated yet
+          ...LOCALES.ENGLISH.messages,
+          ...i18nUtil.getLocaleByCode(language.current)?.messages,
+        }}
         locale={language.current}
         defaultLocale={LOCALES.ENGLISH.code}
       >


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes

I used Claude as a help during the work on this change. I reviewed every line, tested it by hand on my own instance and I take responsibility for the code.

## What's new?

Related to #150.

Every translation file misses some keys that exist in the English file. When a key is missing, the UI shows the technical key instead of a normal text, for example `admin.shares.table.deletes`.

This change merges the English texts under the texts of the active language. When a translation is missing, the user now sees the English text. Translated texts work exactly like before. The merged object is memoized, because the language can only change with a full page reload, so it is built only once.

## How has it been tested?

I switched the UI to Polish and to German. Keys with no translation now show the English text. Translated keys look the same as before. Type check, lint and the production build pass.

## Screenshots

N/A