### PR TITLE
feat(admin): sortable columns and search in the share table

### DIFF
--- a/frontend/src/components/admin/shares/ManageShareTable.tsx
+++ b/frontend/src/components/admin/shares/ManageShareTable.tsx
@@ -10,6 +10,7 @@ import {
 import { useClipboard } from "@mantine/hooks";
 import { useModals } from "@mantine/modals";
 import moment from "moment";
+import { useState } from "react";
 import { TbInfoCircle, TbLink, TbTrash } from "react-icons/tb";
 import { FormattedMessage } from "react-intl";
 import useConfig from "../../../hooks/config.hook";
@@ -37,33 +38,58 @@ const ManageShareTable = ({
   const config = useConfig();
   const t = useTranslate();
 
+  const [sort, setSort] = useState<{ column: string; asc: boolean }>();
+
   // Check if file retention is enabled
   const fileRetentionPeriod = config.get("share.fileRetentionPeriod");
   const fileRetentionEnabled = fileRetentionPeriod.value !== 0 ? true : false;
+
+  const sortValue = (share: MyShare, column: string) => {
+    if (column == "views") return share.views;
+    if (column == "size") return share.size;
+    if (column == "expiration") return moment(share.expiration).unix();
+    if (column == "username")
+      return share.creator?.username.toLowerCase() ?? "";
+    if (column == "name") return (share.name ?? "").toLowerCase();
+    return share.id.toLowerCase();
+  };
+
+  const visibleShares = [...shares];
+  if (sort) {
+    visibleShares.sort((a, b) => {
+      const va = sortValue(a, sort.column);
+      const vb = sortValue(b, sort.column);
+      const order = va < vb ? -1 : va > vb ? 1 : 0;
+      return sort.asc ? order : -order;
+    });
+  }
+
+  const toggleSort = (column: string) => {
+    setSort(
+      sort?.column === column
+        ? { column, asc: !sort.asc }
+        : { column, asc: true },
+    );
+  };
+
+  const sortableTh = (column: string, messageId: string) => (
+    <th style={{ cursor: "pointer" }} onClick={() => toggleSort(column)}>
+      <FormattedMessage id={messageId} />
+      {sort?.column === column && (sort.asc ? " ▲" : " ▼")}
+    </th>
+  );
 
   return (
     <Box sx={{ display: "block", overflowX: "auto" }}>
       <Table verticalSpacing="sm">
         <thead>
           <tr>
-            <th>
-              <FormattedMessage id="account.shares.table.id" />
-            </th>
-            <th>
-              <FormattedMessage id="account.shares.table.name" />
-            </th>
-            <th>
-              <FormattedMessage id="admin.shares.table.username" />
-            </th>
-            <th>
-              <FormattedMessage id="account.shares.table.visitors" />
-            </th>
-            <th>
-              <FormattedMessage id="account.shares.table.size" />
-            </th>
-            <th>
-              <FormattedMessage id="account.shares.table.expiresAt" />
-            </th>
+            {sortableTh("id", "account.shares.table.id")}
+            {sortableTh("name", "account.shares.table.name")}
+            {sortableTh("username", "admin.shares.table.username")}
+            {sortableTh("views", "account.shares.table.visitors")}
+            {sortableTh("size", "account.shares.table.size")}
+            {sortableTh("expiration", "account.shares.table.expiresAt")}
             {fileRetentionEnabled ? (
               <th>
                 <FormattedMessage id="admin.shares.table.deletes" />
@@ -77,7 +103,7 @@ const ManageShareTable = ({
         <tbody>
           {isLoading
             ? skeletonRows
-            : shares.map((share) => (
+            : visibleShares.map((share) => (
                 <tr key={share.id}>
                   <td>{share.id}</td>
                   <td>{share.name}</td>

--- a/frontend/src/components/admin/shares/ManageShareTable.tsx
+++ b/frontend/src/components/admin/shares/ManageShareTable.tsx
@@ -6,12 +6,13 @@ import {
   Skeleton,
   Table,
   Text,
+  TextInput,
 } from "@mantine/core";
 import { useClipboard } from "@mantine/hooks";
 import { useModals } from "@mantine/modals";
 import moment from "moment";
 import { useState } from "react";
-import { TbInfoCircle, TbLink, TbTrash } from "react-icons/tb";
+import { TbInfoCircle, TbLink, TbSearch, TbTrash } from "react-icons/tb";
 import { FormattedMessage } from "react-intl";
 import useConfig from "../../../hooks/config.hook";
 import useTranslate from "../../../hooks/useTranslate.hook";
@@ -38,6 +39,7 @@ const ManageShareTable = ({
   const config = useConfig();
   const t = useTranslate();
 
+  const [search, setSearch] = useState("");
   const [sort, setSort] = useState<{ column: string; asc: boolean }>();
 
   // Check if file retention is enabled
@@ -54,7 +56,13 @@ const ManageShareTable = ({
     return share.id.toLowerCase();
   };
 
-  const visibleShares = [...shares];
+  const needle = search.toLowerCase();
+  const visibleShares = shares.filter(
+    (share) =>
+      share.id.toLowerCase().includes(needle) ||
+      (share.name ?? "").toLowerCase().includes(needle) ||
+      (share.creator?.username ?? "").toLowerCase().includes(needle),
+  );
   if (sort) {
     visibleShares.sort((a, b) => {
       const va = sortValue(a, sort.column);
@@ -81,6 +89,13 @@ const ManageShareTable = ({
 
   return (
     <Box sx={{ display: "block", overflowX: "auto" }}>
+      <TextInput
+        placeholder={t("admin.shares.search")}
+        icon={<TbSearch />}
+        value={search}
+        onChange={(e) => setSearch(e.currentTarget.value)}
+        mb="md"
+      />
       <Table verticalSpacing="sm">
         <thead>
           <tr>

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -311,6 +311,8 @@ export default {
   "admin.shares.edit.delete.description":
     "Do you really want to delete this share?",
 
+  "admin.shares.search": "Search",
+
   // END /admin/shares
 
   // /upload


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Feature

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes

I used Claude as a help during the work on this change. I reviewed every line, tested it by hand on my own instance and I take responsibility for the code.

## What's new?

First part of #150. This adds two things to the admin share table:

- Click a column header to sort by it. Click again to reverse the order. Works for id, name, creator, visitors, size and expiry date.
- A search box that filters by share id, name or creator name, case insensitive.

Both run on the client, no backend or API changes. The next PRs in this series will add checkboxes with bulk delete, paging for large lists, a created date column with time filters, and auto refresh.

## How has it been tested?

I tested this by hand with a few thousand shares on my own instance. I clicked every column header and checked the sort order in both directions. I tried the search box with matches on id, name and creator, and with no match. Type check, lint and the production build all pass.

## Screenshots

N/A