### PR TITLE
feat(admin): select shares and delete many at once

### DIFF
--- a/frontend/src/components/admin/shares/ManageShareTable.tsx
+++ b/frontend/src/components/admin/shares/ManageShareTable.tsx
@@ -1,6 +1,8 @@
 import {
   ActionIcon,
   Box,
+  Button,
+  Checkbox,
   Group,
   MediaQuery,
   Skeleton,
@@ -27,11 +29,13 @@ const ManageShareTable = ({
   shares,
   updateShare,
   deleteShare,
+  deleteShares,
   isLoading,
 }: {
   shares: MyShare[];
   updateShare: (share: MyShare) => void;
   deleteShare: (share: MyShare) => void;
+  deleteShares: (shares: MyShare[]) => void;
   isLoading: boolean;
 }) => {
   const modals = useModals();
@@ -41,6 +45,7 @@ const ManageShareTable = ({
 
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<{ column: string; asc: boolean }>();
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
 
   // Check if file retention is enabled
   const fileRetentionPeriod = config.get("share.fileRetentionPeriod");
@@ -87,18 +92,63 @@ const ManageShareTable = ({
     </th>
   );
 
+  const selectedShares = shares.filter((share) =>
+    selectedIds.includes(share.id),
+  );
+  const allVisibleSelected =
+    visibleShares.length > 0 &&
+    visibleShares.every((share) => selectedIds.includes(share.id));
+
+  const toggleAll = () => {
+    if (allVisibleSelected) {
+      setSelectedIds(
+        selectedIds.filter(
+          (id) => !visibleShares.some((share) => share.id === id),
+        ),
+      );
+    } else {
+      setSelectedIds([
+        ...new Set([...selectedIds, ...visibleShares.map((share) => share.id)]),
+      ]);
+    }
+  };
+
+  const toggleRow = (id: string) => {
+    setSelectedIds(
+      selectedIds.includes(id)
+        ? selectedIds.filter((v) => v !== id)
+        : [...selectedIds, id],
+    );
+  };
+
   return (
     <Box sx={{ display: "block", overflowX: "auto" }}>
-      <TextInput
-        placeholder={t("admin.shares.search")}
-        icon={<TbSearch />}
-        value={search}
-        onChange={(e) => setSearch(e.currentTarget.value)}
-        mb="md"
-      />
+      <Group position="apart" mb="md">
+        <TextInput
+          placeholder={t("admin.shares.search")}
+          icon={<TbSearch />}
+          value={search}
+          onChange={(e) => setSearch(e.currentTarget.value)}
+        />
+        {selectedShares.length > 0 && (
+          <Button
+            variant="light"
+            color="red"
+            leftIcon={<TbTrash />}
+            onClick={() => deleteShares(selectedShares)}
+          >
+            {t("admin.shares.button.delete-selected", {
+              count: selectedShares.length,
+            })}
+          </Button>
+        )}
+      </Group>
       <Table verticalSpacing="sm">
         <thead>
           <tr>
+            <th style={{ width: 30 }}>
+              <Checkbox checked={allVisibleSelected} onChange={toggleAll} />
+            </th>
             {sortableTh("id", "account.shares.table.id")}
             {sortableTh("name", "account.shares.table.name")}
             {sortableTh("username", "admin.shares.table.username")}
@@ -120,6 +170,12 @@ const ManageShareTable = ({
             ? skeletonRows
             : visibleShares.map((share) => (
                 <tr key={share.id}>
+                  <td>
+                    <Checkbox
+                      checked={selectedIds.includes(share.id)}
+                      onChange={() => toggleRow(share.id)}
+                    />
+                  </td>
                   <td>{share.id}</td>
                   <td>{share.name}</td>
                   <td>

--- a/frontend/src/components/admin/shares/ManageShareTable.tsx
+++ b/frontend/src/components/admin/shares/ManageShareTable.tsx
@@ -13,7 +13,7 @@ import {
 import { useClipboard } from "@mantine/hooks";
 import { useModals } from "@mantine/modals";
 import moment from "moment";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { TbInfoCircle, TbLink, TbSearch, TbTrash } from "react-icons/tb";
 import { FormattedMessage } from "react-intl";
 import useConfig from "../../../hooks/config.hook";
@@ -45,37 +45,30 @@ const ManageShareTable = ({
 
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<{ column: string; asc: boolean }>();
-  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
   // Check if file retention is enabled
   const fileRetentionPeriod = config.get("share.fileRetentionPeriod");
   const fileRetentionEnabled = fileRetentionPeriod.value !== 0 ? true : false;
 
-  const sortValue = (share: MyShare, column: string) => {
-    if (column == "views") return share.views;
-    if (column == "size") return share.size;
-    if (column == "expiration") return moment(share.expiration).unix();
-    if (column == "username")
-      return share.creator?.username.toLowerCase() ?? "";
-    if (column == "name") return (share.name ?? "").toLowerCase();
-    return share.id.toLowerCase();
-  };
-
-  const needle = search.toLowerCase();
-  const visibleShares = shares.filter(
-    (share) =>
-      share.id.toLowerCase().includes(needle) ||
-      (share.name ?? "").toLowerCase().includes(needle) ||
-      (share.creator?.username ?? "").toLowerCase().includes(needle),
-  );
-  if (sort) {
-    visibleShares.sort((a, b) => {
-      const va = sortValue(a, sort.column);
-      const vb = sortValue(b, sort.column);
-      const order = va < vb ? -1 : va > vb ? 1 : 0;
-      return sort.asc ? order : -order;
-    });
-  }
+  const visibleShares = useMemo(() => {
+    const needle = search.toLowerCase();
+    const filtered = shares.filter(
+      (share) =>
+        share.id.toLowerCase().includes(needle) ||
+        (share.name ?? "").toLowerCase().includes(needle) ||
+        (share.creator?.username ?? "").toLowerCase().includes(needle),
+    );
+    if (sort) {
+      filtered.sort((a, b) => {
+        const va = sortValue(a, sort.column);
+        const vb = sortValue(b, sort.column);
+        const order = va < vb ? -1 : va > vb ? 1 : 0;
+        return sort.asc ? order : -order;
+      });
+    }
+    return filtered;
+  }, [shares, search, sort]);
 
   const toggleSort = (column: string) => {
     setSort(
@@ -85,41 +78,37 @@ const ManageShareTable = ({
     );
   };
 
+  const selectedShares = shares.filter((share) => selectedIds.has(share.id));
+  const allVisibleSelected =
+    visibleShares.length > 0 &&
+    visibleShares.every((share) => selectedIds.has(share.id));
+
+  const toggleAll = () => {
+    const next = new Set(selectedIds);
+    if (allVisibleSelected) {
+      visibleShares.forEach((share) => next.delete(share.id));
+    } else {
+      visibleShares.forEach((share) => next.add(share.id));
+    }
+    setSelectedIds(next);
+  };
+
+  const toggleRow = (id: string) => {
+    const next = new Set(selectedIds);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    setSelectedIds(next);
+  };
+
   const sortableTh = (column: string, messageId: string) => (
     <th style={{ cursor: "pointer" }} onClick={() => toggleSort(column)}>
       <FormattedMessage id={messageId} />
       {sort?.column === column && (sort.asc ? " ▲" : " ▼")}
     </th>
   );
-
-  const selectedShares = shares.filter((share) =>
-    selectedIds.includes(share.id),
-  );
-  const allVisibleSelected =
-    visibleShares.length > 0 &&
-    visibleShares.every((share) => selectedIds.includes(share.id));
-
-  const toggleAll = () => {
-    if (allVisibleSelected) {
-      setSelectedIds(
-        selectedIds.filter(
-          (id) => !visibleShares.some((share) => share.id === id),
-        ),
-      );
-    } else {
-      setSelectedIds([
-        ...new Set([...selectedIds, ...visibleShares.map((share) => share.id)]),
-      ]);
-    }
-  };
-
-  const toggleRow = (id: string) => {
-    setSelectedIds(
-      selectedIds.includes(id)
-        ? selectedIds.filter((v) => v !== id)
-        : [...selectedIds, id],
-    );
-  };
 
   return (
     <Box sx={{ display: "block", overflowX: "auto" }}>
@@ -172,7 +161,7 @@ const ManageShareTable = ({
                 <tr key={share.id}>
                   <td>
                     <Checkbox
-                      checked={selectedIds.includes(share.id)}
+                      checked={selectedIds.has(share.id)}
                       onChange={() => toggleRow(share.id)}
                     />
                   </td>
@@ -271,6 +260,15 @@ const ManageShareTable = ({
       </Table>
     </Box>
   );
+};
+
+const sortValue = (share: MyShare, column: string) => {
+  if (column == "views") return share.views;
+  if (column == "size") return share.size;
+  if (column == "expiration") return moment(share.expiration).unix();
+  if (column == "username") return share.creator?.username.toLowerCase() ?? "";
+  if (column == "name") return (share.name ?? "").toLowerCase();
+  return share.id.toLowerCase();
 };
 
 const skeletonRows = [...Array(10)].map((v, i) => (

--- a/frontend/src/components/admin/shares/ManageShareTable.tsx
+++ b/frontend/src/components/admin/shares/ManageShareTable.tsx
@@ -10,6 +10,7 @@ import {
 import { useClipboard } from "@mantine/hooks";
 import { useModals } from "@mantine/modals";
 import moment from "moment";
+import { useState } from "react";
 import { TbInfoCircle, TbLink, TbTrash } from "react-icons/tb";
 import { FormattedMessage } from "react-intl";
 import useConfig from "../../../hooks/config.hook";
@@ -37,33 +38,58 @@ const ManageShareTable = ({
   const config = useConfig();
   const t = useTranslate();
 
+  const [sort, setSort] = useState<{ column: string; asc: boolean }>();
+
   // Check if file retention is enabled
   const fileRetentionPeriod = config.get("share.fileRetentionPeriod");
   const fileRetentionEnabled = fileRetentionPeriod.value !== 0 ? true : false;
+
+  const sortValue = (share: MyShare, column: string) => {
+    if (column == "views") return share.views;
+    if (column == "size") return share.size;
+    if (column == "expiration") return moment(share.expiration).unix();
+    if (column == "username")
+      return share.creator?.username.toLowerCase() ?? "";
+    if (column == "name") return (share.name ?? "").toLowerCase();
+    return share.id.toLowerCase();
+  };
+
+  const visibleShares = [...shares];
+  if (sort) {
+    visibleShares.sort((a, b) => {
+      const va = sortValue(a, sort.column);
+      const vb = sortValue(b, sort.column);
+      const order = va < vb ? -1 : va > vb ? 1 : 0;
+      return sort.asc ? order : -order;
+    });
+  }
+
+  const toggleSort = (column: string) => {
+    setSort(
+      sort?.column === column
+        ? { column, asc: !sort.asc }
+        : { column, asc: true },
+    );
+  };
+
+  const sortableTh = (column: string, messageId: string) => (
+    <th style={{ cursor: "pointer" }} onClick={() => toggleSort(column)}>
+      <FormattedMessage id={messageId} />
+      {sort?.column === column && (sort.asc ? " ▲" : " ▼")}
+    </th>
+  );
 
   return (
     <Box sx={{ display: "block", overflowX: "auto" }}>
       <Table verticalSpacing="sm">
         <thead>
           <tr>
-            <th>
-              <FormattedMessage id="account.shares.table.id" />
-            </th>
-            <th>
-              <FormattedMessage id="account.shares.table.name" />
-            </th>
-            <th>
-              <FormattedMessage id="admin.shares.table.username" />
-            </th>
-            <th>
-              <FormattedMessage id="account.shares.table.visitors" />
-            </th>
-            <th>
-              <FormattedMessage id="account.shares.table.size" />
-            </th>
-            <th>
-              <FormattedMessage id="account.shares.table.expiresAt" />
-            </th>
+            {sortableTh("id", "account.shares.table.id")}
+            {sortableTh("name", "account.shares.table.name")}
+            {sortableTh("username", "admin.shares.table.username")}
+            {sortableTh("views", "account.shares.table.visitors")}
+            {sortableTh("size", "account.shares.table.size")}
+            {sortableTh("expiration", "account.shares.table.expiresAt")}
             {fileRetentionEnabled ? (
               <th>
                 <FormattedMessage id="admin.shares.table.deletes" />
@@ -77,7 +103,7 @@ const ManageShareTable = ({
         <tbody>
           {isLoading
             ? skeletonRows
-            : shares.map((share) => (
+            : visibleShares.map((share) => (
                 <tr key={share.id}>
                   <td>{share.id}</td>
                   <td>{share.name}</td>

--- a/frontend/src/components/admin/shares/ManageShareTable.tsx
+++ b/frontend/src/components/admin/shares/ManageShareTable.tsx
@@ -6,12 +6,13 @@ import {
   Skeleton,
   Table,
   Text,
+  TextInput,
 } from "@mantine/core";
 import { useClipboard } from "@mantine/hooks";
 import { useModals } from "@mantine/modals";
 import moment from "moment";
 import { useState } from "react";
-import { TbInfoCircle, TbLink, TbTrash } from "react-icons/tb";
+import { TbInfoCircle, TbLink, TbSearch, TbTrash } from "react-icons/tb";
 import { FormattedMessage } from "react-intl";
 import useConfig from "../../../hooks/config.hook";
 import useTranslate from "../../../hooks/useTranslate.hook";
@@ -38,6 +39,7 @@ const ManageShareTable = ({
   const config = useConfig();
   const t = useTranslate();
 
+  const [search, setSearch] = useState("");
   const [sort, setSort] = useState<{ column: string; asc: boolean }>();
 
   // Check if file retention is enabled
@@ -54,7 +56,13 @@ const ManageShareTable = ({
     return share.id.toLowerCase();
   };
 
-  const visibleShares = [...shares];
+  const needle = search.toLowerCase();
+  const visibleShares = shares.filter(
+    (share) =>
+      share.id.toLowerCase().includes(needle) ||
+      (share.name ?? "").toLowerCase().includes(needle) ||
+      (share.creator?.username ?? "").toLowerCase().includes(needle),
+  );
   if (sort) {
     visibleShares.sort((a, b) => {
       const va = sortValue(a, sort.column);
@@ -81,6 +89,13 @@ const ManageShareTable = ({
 
   return (
     <Box sx={{ display: "block", overflowX: "auto" }}>
+      <TextInput
+        placeholder={t("admin.shares.search")}
+        icon={<TbSearch />}
+        value={search}
+        onChange={(e) => setSearch(e.currentTarget.value)}
+        mb="md"
+      />
       <Table verticalSpacing="sm">
         <thead>
           <tr>

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -312,6 +312,10 @@ export default {
     "Do you really want to delete this share?",
 
   "admin.shares.search": "Search",
+  "admin.shares.button.delete-selected": "Delete selected ({count})",
+  "admin.shares.modal.delete-selected.title": "Delete {count} shares",
+  "admin.shares.modal.delete-selected.description":
+    "Do you really want to delete these shares?",
 
   // END /admin/shares
 

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -311,6 +311,8 @@ export default {
   "admin.shares.edit.delete.description":
     "Do you really want to delete this share?",
 
+  "admin.shares.search": "Search",
+
   // END /admin/shares
 
   // /upload

--- a/frontend/src/pages/admin/shares.tsx
+++ b/frontend/src/pages/admin/shares.tsx
@@ -49,6 +49,30 @@ const Shares = () => {
     });
   };
 
+  const deleteShares = (toDelete: MyShare[]) => {
+    modals.openConfirmModal({
+      title: t("admin.shares.modal.delete-selected.title", {
+        count: toDelete.length,
+      }),
+      children: (
+        <Text size="sm">
+          <FormattedMessage id="admin.shares.modal.delete-selected.description" />
+        </Text>
+      ),
+      labels: {
+        confirm: t("common.button.delete"),
+        cancel: t("common.button.cancel"),
+      },
+      confirmProps: { color: "red" },
+      onConfirm: async () => {
+        await Promise.all(
+          toDelete.map((share) => shareService.remove(share.id)),
+        ).catch(toast.axiosError);
+        getShares();
+      },
+    });
+  };
+
   useEffect(() => {
     getShares();
   }, []);
@@ -73,6 +97,7 @@ const Shares = () => {
           )
         }
         deleteShare={deleteShare}
+        deleteShares={deleteShares}
         isLoading={isLoading}
       />
       <Space h="xl" />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Feature

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes

I used Claude as a help during the work on this change. I reviewed every line, tested it by hand on my own instance and I take responsibility for the code.

## What's new?

Part of #150. This is stacked on top of #152 (sorting and search), so the diff here also shows those two commits until #152 is merged. Once #152 merges, this PR will only show the two new commits below.

New in this PR:

- A checkbox on each row, plus a checkbox in the header to select or clear all shares that match the current search.
- A red button appears when at least one share is selected, to delete all of them at once with one confirm dialog.
- The filtering logic now runs in a memo, and selection is stored in a Set instead of an array, so this stays fast even with a few thousand shares selected.

## How has it been tested?

I tested this by hand on my own instance with a few thousand shares. I selected single rows, selected all with the header checkbox, combined it with the search box, and deleted a batch. I also checked that the list and the selection stay correct after the delete finishes. Type check, lint and the production build all pass.

## Screenshots

N/A