### PR TITLE
feat(uploads): text based progress indicator & time remaining

### DIFF
--- a/backend/prisma/seed/config.seed.ts
+++ b/backend/prisma/seed/config.seed.ts
@@ -66,6 +66,11 @@ export const configVariables = {
       defaultValue: "",
       secret: false,
     },
+    uploadProgressStyle: {
+      type: "string",
+      defaultValue: "circle",
+      secret: false,
+    },
   },
   share: {
     allowRegistration: {

--- a/frontend/src/components/admin/configuration/AdminConfigInput.tsx
+++ b/frontend/src/components/admin/configuration/AdminConfigInput.tsx
@@ -23,6 +23,7 @@ import { stringToTimespan, timespanToString } from "../../../utils/date.util";
 import FileSizeInput from "../../core/FileSizeInput";
 import TimespanInput from "../../core/TimespanInput";
 import { LOCALES } from "../../../i18n/locales";
+import useTranslate from "../../../hooks/useTranslate.hook";
 
 const AdminConfigInput = ({
   configVariable,
@@ -37,6 +38,7 @@ const AdminConfigInput = ({
   updatedConfigVariables?: UpdateConfig[];
   optionalConfigVariables?: AdminConfig[];
 }) => {
+  const t = useTranslate();
   const isCustomCssConfig = configVariable.key === "appearance.customCss";
   const isThemePrimaryColorConfig =
     configVariable.key === "appearance.themePrimaryColor";
@@ -47,6 +49,8 @@ const AdminConfigInput = ({
     configVariable.key === "appearance.themeColorScheme";
   const isDefaultLanguageConfig =
     configVariable.key === "general.defaultLanguage";
+  const isUploadProgressStyleConfig =
+    configVariable.key === "appearance.uploadProgressStyle";
   const isEmailShareConfig =
     configVariable.key === "email.enableShareEmailRecipients";
   const isEmailVerificationConfig =
@@ -245,6 +249,21 @@ const AdminConfigInput = ({
             ]}
             value={form.values.stringValue}
             onChange={(value) => onValueChange(configVariable, value)}
+          />
+        ) : isUploadProgressStyleConfig ? (
+          <Select
+            style={{
+              width: "100%",
+            }}
+            disabled={!configVariable.allowEdit}
+            data={[
+              { value: "circle", label: t("admin.config.appearance.upload-progress-style.circle") },
+              { value: "percentage-time", label: t("admin.config.appearance.upload-progress-style.percentage-time") },
+            ]}
+            value={form.values.stringValue}
+            placeholder={configVariable.defaultValue}
+            onChange={(value) => onValueChange(configVariable, value ?? "")}
+            allowDeselect={false}
           />
         ) : (
           <TextInput

--- a/frontend/src/components/admin/configuration/AdminConfigInput.tsx
+++ b/frontend/src/components/admin/configuration/AdminConfigInput.tsx
@@ -257,8 +257,24 @@ const AdminConfigInput = ({
             }}
             disabled={!configVariable.allowEdit}
             data={[
-              { value: "circle", label: t("admin.config.appearance.upload-progress-style.circle") },
-              { value: "percentage-time", label: t("admin.config.appearance.upload-progress-style.percentage-time") },
+              {
+                value: "circle",
+                label: t(
+                  "admin.config.appearance.upload-progress-style.circle",
+                ),
+              },
+              {
+                value: "circle-percentage",
+                label: t(
+                  "admin.config.appearance.upload-progress-style.circle-percentage",
+                ),
+              },
+              {
+                value: "percentage-time",
+                label: t(
+                  "admin.config.appearance.upload-progress-style.percentage-time",
+                ),
+              },
             ]}
             value={form.values.stringValue}
             placeholder={configVariable.defaultValue}

--- a/frontend/src/components/upload/FileList.tsx
+++ b/frontend/src/components/upload/FileList.tsx
@@ -25,9 +25,10 @@ const renderFileName = (name: string) => {
 };
 
 const getFileNameOrPath = (file: FileListItem) => {
-  const pathName = ("webkitRelativePath" in file && file.webkitRelativePath)
-    ? file.webkitRelativePath
-    : file.name;
+  const pathName =
+    "webkitRelativePath" in file && file.webkitRelativePath
+      ? file.webkitRelativePath
+      : file.name;
   return pathName.replace(/\\/g, "/").replace(/^\//, "");
 };
 
@@ -69,43 +70,73 @@ const FileListRow = ({
         <td>
           <Group position="right" spacing="xs" noWrap>
             {editable && (
-              <HoverTip label={t("common.button.edit")}>
-                <ActionIcon
-                  color="blue"
-                  variant="light"
-                  size={25}
-                  onClick={onEdit}
-                >
-                  <TbEdit />
-                </ActionIcon>
-              </HoverTip>
+              <div
+                style={{
+                  display: "inline-flex",
+                  justifyContent: "center",
+                  alignItems: "center",
+                  width: 40,
+                  height: 40,
+                }}
+              >
+                <HoverTip label={t("common.button.edit")}>
+                  <ActionIcon
+                    color="blue"
+                    variant="light"
+                    size={25}
+                    onClick={onEdit}
+                  >
+                    <TbEdit />
+                  </ActionIcon>
+                </HoverTip>
+              </div>
             )}
             {removable && (
-              <HoverTip label={t("common.button.delete")}>
-                <ActionIcon
-                  color="red"
-                  variant="light"
-                  size={25}
-                  onClick={onRemove}
-                >
-                  <TbTrash />
-                </ActionIcon>
-              </HoverTip>
+              <div
+                style={{
+                  display: "inline-flex",
+                  justifyContent: "center",
+                  alignItems: "center",
+                  width: 40,
+                  height: 40,
+                }}
+              >
+                <HoverTip label={t("common.button.delete")}>
+                  <ActionIcon
+                    color="red"
+                    variant="light"
+                    size={25}
+                    onClick={onRemove}
+                  >
+                    <TbTrash />
+                  </ActionIcon>
+                </HoverTip>
+              </div>
             )}
             {uploading && (
               <UploadProgressIndicator progress={file.uploadingProgress} />
             )}
             {restorable && (
-              <HoverTip label={t("common.button.undo")}>
-                <ActionIcon
-                  color="victoria"
-                  variant="light"
-                  size={25}
-                  onClick={onRestore}
-                >
-                  <GrUndo />
-                </ActionIcon>
-              </HoverTip>
+              <div
+                style={{
+                  display: "inline-flex",
+                  justifyContent: "center",
+                  alignItems: "center",
+                  width: 40,
+                  height: 40,
+                }}
+              >
+                <HoverTip label={t("common.button.undo")}>
+                  <ActionIcon
+                    color="victoria"
+                    variant="light"
+                    size={25}
+                    onClick={onRestore}
+                  >
+                    <GrUndo />
+                  </ActionIcon>
+                </HoverTip>
+              </div>
             )}
           </Group>
         </td>

--- a/frontend/src/components/upload/FileList.tsx
+++ b/frontend/src/components/upload/FileList.tsx
@@ -70,73 +70,43 @@ const FileListRow = ({
         <td>
           <Group position="right" spacing="xs" noWrap>
             {editable && (
-              <div
-                style={{
-                  display: "inline-flex",
-                  justifyContent: "center",
-                  alignItems: "center",
-                  width: 40,
-                  height: 40,
-                }}
-              >
-                <HoverTip label={t("common.button.edit")}>
-                  <ActionIcon
-                    color="blue"
-                    variant="light"
-                    size={25}
-                    onClick={onEdit}
-                  >
-                    <TbEdit />
-                  </ActionIcon>
-                </HoverTip>
-              </div>
+              <HoverTip label={t("common.button.edit")}>
+                <ActionIcon
+                  color="blue"
+                  variant="light"
+                  size={25}
+                  onClick={onEdit}
+                >
+                  <TbEdit />
+                </ActionIcon>
+              </HoverTip>
             )}
             {removable && (
-              <div
-                style={{
-                  display: "inline-flex",
-                  justifyContent: "center",
-                  alignItems: "center",
-                  width: 40,
-                  height: 40,
-                }}
-              >
-                <HoverTip label={t("common.button.delete")}>
-                  <ActionIcon
-                    color="red"
-                    variant="light"
-                    size={25}
-                    onClick={onRemove}
-                  >
-                    <TbTrash />
-                  </ActionIcon>
-                </HoverTip>
-              </div>
+              <HoverTip label={t("common.button.delete")}>
+                <ActionIcon
+                  color="red"
+                  variant="light"
+                  size={25}
+                  onClick={onRemove}
+                >
+                  <TbTrash />
+                </ActionIcon>
+              </HoverTip>
             )}
             {uploading && (
               <UploadProgressIndicator progress={file.uploadingProgress} />
             )}
             {restorable && (
-              <div
-                style={{
-                  display: "inline-flex",
-                  justifyContent: "center",
-                  alignItems: "center",
-                  width: 40,
-                  height: 40,
-                }}
-              >
-                <HoverTip label={t("common.button.undo")}>
-                  <ActionIcon
-                    color="victoria"
-                    variant="light"
-                    size={25}
-                    onClick={onRestore}
-                  >
-                    <GrUndo />
-                  </ActionIcon>
-                </HoverTip>
-              </div>
+              <HoverTip label={t("common.button.undo")}>
+                <ActionIcon
+                  color="victoria"
+                  variant="light"
+                  size={25}
+                  onClick={onRestore}
+                >
+                  <GrUndo />
+                </ActionIcon>
+              </HoverTip>
             )}
           </Group>
         </td>

--- a/frontend/src/components/upload/UploadProgressIndicator.tsx
+++ b/frontend/src/components/upload/UploadProgressIndicator.tsx
@@ -1,18 +1,90 @@
+import { useEffect, useRef, useState } from "react";
 import { Loader, RingProgress, Text } from "@mantine/core";
 import { TbCircleCheck } from "react-icons/tb";
+import { HoverTip } from "../core/HoverTip";
+import { useIntl } from "react-intl";
+
 const UploadProgressIndicator = ({ progress }: { progress: number }) => {
+  const intl = useIntl();
+  const startTimeRef = useRef<number | null>(null);
+  const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (progress <= 0 || progress >= 100) {
+      startTimeRef.current = null;
+      setRemainingSeconds(null);
+      return;
+    }
+
+    if (!startTimeRef.current) {
+      startTimeRef.current = Date.now();
+      return;
+    }
+
+    const elapsedMs = Date.now() - startTimeRef.current;
+    if (elapsedMs > 500) {
+      const rate = progress / 100;
+      const totalMs = elapsedMs / rate;
+      const remainingMs = totalMs - elapsedMs;
+      setRemainingSeconds(remainingMs / 1000);
+    }
+  }, [progress]);
+
+  const formatRemainingTime = (seconds: number | null): string => {
+    if (seconds === null || !isFinite(seconds) || seconds < 0) {
+      return intl.formatMessage({
+        id: "upload.filelist.estimating",
+      });
+    }
+
+    let timeStr = "";
+    if (seconds < 60) {
+      timeStr = `${Math.round(seconds)}s`;
+    } else {
+      const minutes = Math.floor(seconds / 60);
+      const remainingSeconds = Math.round(seconds % 60);
+      if (minutes < 60) {
+        timeStr = `${minutes}m ${remainingSeconds}s`;
+      } else {
+        const hours = Math.floor(minutes / 60);
+        const remainingMinutes = minutes % 60;
+        timeStr = `${hours}h ${remainingMinutes}m`;
+      }
+    }
+
+    return intl.formatMessage(
+      {
+        id: "upload.filelist.remaining",
+      },
+      { time: timeStr },
+    );
+  };
+
   if (progress > 0 && progress < 100) {
+    const tooltipLabel = formatRemainingTime(remainingSeconds);
     return (
-      <RingProgress
-        sections={[{ value: progress, color: "victoria" }]}
-        thickness={3}
-        size={40}
-        label={
-          <Text size="xs" color="victoria" weight={700} align="center">
-            {Math.round(progress)}%
-          </Text>
-        }
-      />
+      <HoverTip label={tooltipLabel}>
+        <div
+          style={{
+            display: "inline-flex",
+            justifyContent: "center",
+            alignItems: "center",
+            width: 40,
+            height: 40,
+          }}
+        >
+          <RingProgress
+            sections={[{ value: progress, color: "victoria" }]}
+            thickness={3}
+            size={40}
+            label={
+              <Text size="xs" color="victoria" weight={700} align="center">
+                {Math.round(progress)}%
+              </Text>
+            }
+          />
+        </div>
+      </HoverTip>
     );
   } else if (progress >= 100) {
     return (

--- a/frontend/src/components/upload/UploadProgressIndicator.tsx
+++ b/frontend/src/components/upload/UploadProgressIndicator.tsx
@@ -1,4 +1,4 @@
-import { Loader, RingProgress } from "@mantine/core";
+import { Loader, RingProgress, Text } from "@mantine/core";
 import { TbCircleCheck } from "react-icons/tb";
 const UploadProgressIndicator = ({ progress }: { progress: number }) => {
   if (progress > 0 && progress < 100) {
@@ -6,7 +6,12 @@ const UploadProgressIndicator = ({ progress }: { progress: number }) => {
       <RingProgress
         sections={[{ value: progress, color: "victoria" }]}
         thickness={3}
-        size={25}
+        size={40}
+        label={
+          <Text size="xs" color="victoria" weight={700} align="center">
+            {Math.round(progress)}%
+          </Text>
+        }
       />
     );
   } else if (progress >= 100) {

--- a/frontend/src/components/upload/UploadProgressIndicator.tsx
+++ b/frontend/src/components/upload/UploadProgressIndicator.tsx
@@ -68,21 +68,11 @@ const UploadProgressIndicator = ({ progress }: { progress: number }) => {
     if (progressStyle === "circle") {
       return (
         <HoverTip label={tooltipLabel}>
-          <div
-            style={{
-              display: "inline-flex",
-              justifyContent: "center",
-              alignItems: "center",
-              width: 40,
-              height: 40,
-            }}
-          >
-            <RingProgress
-              sections={[{ value: progress, color: "victoria" }]}
-              thickness={3}
-              size={40}
-            />
-          </div>
+          <RingProgress
+            sections={[{ value: progress, color: "victoria" }]}
+            thickness={3}
+            size={25}
+          />
         </HoverTip>
       );
     } else {
@@ -93,33 +83,9 @@ const UploadProgressIndicator = ({ progress }: { progress: number }) => {
       );
     }
   } else if (progress >= 100) {
-    return (
-      <div
-        style={{
-          display: "inline-flex",
-          justifyContent: "center",
-          alignItems: "center",
-          width: 40,
-          height: 40,
-        }}
-      >
-        <TbCircleCheck color="green" size={22} />
-      </div>
-    );
+    return <TbCircleCheck color="green" size={22} />;
   } else {
-    return (
-      <div
-        style={{
-          display: "inline-flex",
-          justifyContent: "center",
-          alignItems: "center",
-          width: 40,
-          height: 40,
-        }}
-      >
-        <Loader color="red" size={19} />
-      </div>
-    );
+    return <Loader color="red" size={19} />;
   }
 };
 

--- a/frontend/src/components/upload/UploadProgressIndicator.tsx
+++ b/frontend/src/components/upload/UploadProgressIndicator.tsx
@@ -78,8 +78,8 @@ const UploadProgressIndicator = ({ progress }: { progress: number }) => {
             thickness={3}
             size={40}
             label={
-              <Text size="xs" color="victoria" weight={700} align="center">
-                {Math.round(progress)}%
+              <Text size="xs" color="victoria" weight={500} align="center">
+                {Math.min(Math.round(progress), 99)}%
               </Text>
             }
           />

--- a/frontend/src/components/upload/UploadProgressIndicator.tsx
+++ b/frontend/src/components/upload/UploadProgressIndicator.tsx
@@ -15,9 +15,33 @@ const UploadProgressIndicator = ({ progress }: { progress: number }) => {
       />
     );
   } else if (progress >= 100) {
-    return <TbCircleCheck color="green" size={22} />;
+    return (
+      <div
+        style={{
+          display: "inline-flex",
+          justifyContent: "center",
+          alignItems: "center",
+          width: 40,
+          height: 40,
+        }}
+      >
+        <TbCircleCheck color="green" size={22} />
+      </div>
+    );
   } else {
-    return <Loader color="red" size={19} />;
+    return (
+      <div
+        style={{
+          display: "inline-flex",
+          justifyContent: "center",
+          alignItems: "center",
+          width: 40,
+          height: 40,
+        }}
+      >
+        <Loader color="red" size={19} />
+      </div>
+    );
   }
 };
 

--- a/frontend/src/components/upload/UploadProgressIndicator.tsx
+++ b/frontend/src/components/upload/UploadProgressIndicator.tsx
@@ -3,9 +3,12 @@ import { Loader, RingProgress, Text } from "@mantine/core";
 import { TbCircleCheck } from "react-icons/tb";
 import { HoverTip } from "../core/HoverTip";
 import { useIntl } from "react-intl";
+import useConfig from "../../hooks/config.hook";
 
 const UploadProgressIndicator = ({ progress }: { progress: number }) => {
   const intl = useIntl();
+  const config = useConfig();
+  const progressStyle = config.get("appearance.uploadProgressStyle") ?? "circle";
   const startTimeRef = useRef<number | null>(null);
   const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
 
@@ -62,30 +65,33 @@ const UploadProgressIndicator = ({ progress }: { progress: number }) => {
 
   if (progress > 0 && progress < 100) {
     const tooltipLabel = formatRemainingTime(remainingSeconds);
-    return (
-      <HoverTip label={tooltipLabel}>
-        <div
-          style={{
-            display: "inline-flex",
-            justifyContent: "center",
-            alignItems: "center",
-            width: 40,
-            height: 40,
-          }}
-        >
-          <RingProgress
-            sections={[{ value: progress, color: "victoria" }]}
-            thickness={3}
-            size={40}
-            label={
-              <Text size="xs" color="victoria" weight={500} align="center">
-                {Math.min(Math.round(progress), 99)}%
-              </Text>
-            }
-          />
-        </div>
-      </HoverTip>
-    );
+    if (progressStyle === "circle") {
+      return (
+        <HoverTip label={tooltipLabel}>
+          <div
+            style={{
+              display: "inline-flex",
+              justifyContent: "center",
+              alignItems: "center",
+              width: 40,
+              height: 40,
+            }}
+          >
+            <RingProgress
+              sections={[{ value: progress, color: "victoria" }]}
+              thickness={3}
+              size={40}
+            />
+          </div>
+        </HoverTip>
+      );
+    } else {
+      return (
+        <Text size="sm" color="dimmed" style={{ whiteSpace: "nowrap" }}>
+          {Math.min(Math.round(progress), 99)}% • {tooltipLabel}
+        </Text>
+      );
+    }
   } else if (progress >= 100) {
     return (
       <div

--- a/frontend/src/components/upload/UploadProgressIndicator.tsx
+++ b/frontend/src/components/upload/UploadProgressIndicator.tsx
@@ -4,11 +4,11 @@ import { TbCircleCheck } from "react-icons/tb";
 import { HoverTip } from "../core/HoverTip";
 import { useIntl } from "react-intl";
 import useConfig from "../../hooks/config.hook";
-
 const UploadProgressIndicator = ({ progress }: { progress: number }) => {
   const intl = useIntl();
   const config = useConfig();
-  const progressStyle = config.get("appearance.uploadProgressStyle") ?? "circle";
+  const progressStyle =
+    config.get("appearance.uploadProgressStyle") ?? "circle";
   const startTimeRef = useRef<number | null>(null);
   const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
 
@@ -75,6 +75,31 @@ const UploadProgressIndicator = ({ progress }: { progress: number }) => {
           />
         </HoverTip>
       );
+    } else if (progressStyle === "circle-percentage") {
+      return (
+        <HoverTip label={tooltipLabel}>
+          <div
+            style={{
+              display: "inline-flex",
+              justifyContent: "center",
+              alignItems: "center",
+              width: 40,
+              height: 40,
+            }}
+          >
+            <RingProgress
+              sections={[{ value: progress, color: "victoria" }]}
+              thickness={3}
+              size={40}
+              label={
+                <Text size="xs" color="victoria" weight={500} align="center">
+                  {Math.min(Math.round(progress), 99)}%
+                </Text>
+              }
+            />
+          </div>
+        </HoverTip>
+      );
     } else {
       return (
         <Text size="sm" color="dimmed" style={{ whiteSpace: "nowrap" }}>
@@ -83,8 +108,38 @@ const UploadProgressIndicator = ({ progress }: { progress: number }) => {
       );
     }
   } else if (progress >= 100) {
+    if (progressStyle === "circle-percentage") {
+      return (
+        <div
+          style={{
+            display: "inline-flex",
+            justifyContent: "center",
+            alignItems: "center",
+            width: 40,
+            height: 40,
+          }}
+        >
+          <TbCircleCheck color="green" size={35} />
+        </div>
+      );
+    }
     return <TbCircleCheck color="green" size={22} />;
   } else {
+    if (progressStyle === "circle-percentage") {
+      return (
+        <div
+          style={{
+            display: "inline-flex",
+            justifyContent: "center",
+            alignItems: "center",
+            width: 40,
+            height: 40,
+          }}
+        >
+          <Loader color="red" size={30} />
+        </div>
+      );
+    }
     return <Loader color="red" size={19} />;
   }
 };

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -490,6 +490,11 @@ export default {
   "admin.config.appearance.custom-css": "Custom CSS",
   "admin.config.appearance.custom-css.description":
     "Global CSS applied to the frontend. Use carefully, as invalid CSS may affect the UI.",
+  "admin.config.appearance.upload-progress-style": "Upload progress style",
+  "admin.config.appearance.upload-progress-style.description":
+    "Choose how upload progress is displayed in the file list",
+  "admin.config.appearance.upload-progress-style.circle": "Circle indicator",
+  "admin.config.appearance.upload-progress-style.percentage-time": "Percentage and time remaining",
   "admin.config.general.app-url": "App URL",
   "admin.config.general.app-url.description":
     "On which URL Pingvin Share is available",

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -492,7 +492,7 @@ export default {
     "Global CSS applied to the frontend. Use carefully, as invalid CSS may affect the UI.",
   "admin.config.appearance.upload-progress-style": "Upload progress style",
   "admin.config.appearance.upload-progress-style.description":
-    "Choose how upload progress is displayed in the file list",
+    "Choose how upload progress is displayed in the file list.",
   "admin.config.appearance.upload-progress-style.circle": "Circle indicator",
   "admin.config.appearance.upload-progress-style.percentage-time": "Percentage and time remaining",
   "admin.config.general.app-url": "App URL",

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -339,6 +339,8 @@ export default {
   // FileList.tsx
   "upload.filelist.name": "Name",
   "upload.filelist.size": "Size",
+  "upload.filelist.estimating": "Estimating...",
+  "upload.filelist.remaining": "{time} remaining",
 
   // showCreateUploadModal.tsx
   "upload.modal.title": "Create Share",

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -494,6 +494,7 @@ export default {
   "admin.config.appearance.upload-progress-style.description":
     "Choose how upload progress is displayed in the file list.",
   "admin.config.appearance.upload-progress-style.circle": "Circle indicator",
+  "admin.config.appearance.upload-progress-style.circle-percentage": "Circle with percentage text inside",
   "admin.config.appearance.upload-progress-style.percentage-time": "Percentage and time remaining",
   "admin.config.general.app-url": "App URL",
   "admin.config.general.app-url.description":

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -494,7 +494,7 @@ export default {
   "admin.config.appearance.upload-progress-style.description":
     "Choose how upload progress is displayed in the file list.",
   "admin.config.appearance.upload-progress-style.circle": "Circle indicator",
-  "admin.config.appearance.upload-progress-style.circle-percentage": "Circle with percentage text inside",
+  "admin.config.appearance.upload-progress-style.circle-percentage": "Circle with percentage",
   "admin.config.appearance.upload-progress-style.percentage-time": "Percentage and time remaining",
   "admin.config.general.app-url": "App URL",
   "admin.config.general.app-url.description":

--- a/frontend/src/pages/upload/index.tsx
+++ b/frontend/src/pages/upload/index.tsx
@@ -114,6 +114,16 @@ const Upload = ({
                 },
                 chunkIndex,
                 chunks,
+                (progressEvent) => {
+                  if (progressEvent.total && file.size > 0) {
+                    const chunkProgress = progressEvent.loaded / progressEvent.total;
+                    const uploadedBytesBeforeThisChunk = chunkIndex * chunkSize.current;
+                    const uploadedBytesInThisChunk = blob.size * chunkProgress;
+                    const totalUploaded = uploadedBytesBeforeThisChunk + uploadedBytesInThisChunk;
+                    const overallPercent = (totalUploaded / file.size) * 100;
+                    setFileProgress(Math.min(overallPercent, 99.9));
+                  }
+                }
               )
               .then((response) => {
                 fileId = response.id;

--- a/frontend/src/pages/upload/index.tsx
+++ b/frontend/src/pages/upload/index.tsx
@@ -19,7 +19,10 @@ import { FileUpload } from "../../types/File.type";
 import { CreateShare, Share } from "../../types/share.type";
 import toast from "../../utils/toast.util";
 import { useRouter } from "next/router";
-import { getNormalizedFileName, filterDuplicateFiles } from "../../utils/file.util";
+import {
+  getNormalizedFileName,
+  filterDuplicateFiles,
+} from "../../utils/file.util";
 
 const promiseLimit = pLimit(3);
 let errorToastShown = false;
@@ -116,14 +119,17 @@ const Upload = ({
                 chunks,
                 (progressEvent) => {
                   if (progressEvent.total && file.size > 0) {
-                    const chunkProgress = progressEvent.loaded / progressEvent.total;
-                    const uploadedBytesBeforeThisChunk = chunkIndex * chunkSize.current;
+                    const chunkProgress =
+                      progressEvent.loaded / progressEvent.total;
+                    const uploadedBytesBeforeThisChunk =
+                      chunkIndex * chunkSize.current;
                     const uploadedBytesInThisChunk = blob.size * chunkProgress;
-                    const totalUploaded = uploadedBytesBeforeThisChunk + uploadedBytesInThisChunk;
+                    const totalUploaded =
+                      uploadedBytesBeforeThisChunk + uploadedBytesInThisChunk;
                     const overallPercent = (totalUploaded / file.size) * 100;
                     setFileProgress(Math.min(overallPercent, 99.9));
                   }
-                }
+                },
               )
               .then((response) => {
                 fileId = response.id;
@@ -179,10 +185,10 @@ const Upload = ({
   };
 
   const handleDropzoneFilesChanged = (newFiles: FileUpload[]) => {
-    const filtered = filterDuplicateFiles(
-      newFiles,
-      files,
-      (normalizedName) => toast.error(t("upload.notify.duplicate-skipped", { name: normalizedName }))
+    const filtered = filterDuplicateFiles(newFiles, files, (normalizedName) =>
+      toast.error(
+        t("upload.notify.duplicate-skipped", { name: normalizedName }),
+      ),
     );
     if (filtered.length === 0) return;
 
@@ -228,7 +234,10 @@ const Upload = ({
         const filtered = filterDuplicateFiles(
           [fileUpload],
           files,
-          (normalizedName) => toast.error(t("upload.notify.duplicate-skipped", { name: normalizedName }))
+          (normalizedName) =>
+            toast.error(
+              t("upload.notify.duplicate-skipped", { name: normalizedName }),
+            ),
         );
         if (filtered.length === 0) return;
 

--- a/frontend/src/services/share.service.ts
+++ b/frontend/src/services/share.service.ts
@@ -132,6 +132,7 @@ const uploadFile = async (
   },
   chunkIndex: number,
   totalChunks: number,
+  onUploadProgress?: (progressEvent: any) => void,
 ): Promise<FileUploadResponse> => {
   if (!isValidId(shareId)) throw new Error("Invalid Share ID");
   return (
@@ -143,6 +144,7 @@ const uploadFile = async (
         chunkIndex,
         totalChunks,
       },
+      onUploadProgress,
     })
   ).data;
 };


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

GitHub Copilot was used for autocomplete. It generated the majority of the boilerplate time calculation code for commit `4683bb8`.

## What's new?
- The upload progress indicator (a circle that fills) now contains a text based indicator within the circle to show **per file** upload progress.
  - Icons in the upload status column are a bit bigger to accommodate this.
- Hovering over the upload progress indicator now shows a time remaining estimate for that file.
- Upload progress is now updated much more frequently to complement the above two additions. Previously, it only updated per chunk (default 10MB) now it should reflect more or less the actual state.

## How has it been tested?
- Uploaded single large file and watched to ensure progress numbers increase as expected, in line with the circle filling.
- Uploaded 6 files, because uploads are completed in batches of 3. Files that aren't yet being uploaded correctly show the delete icon, instead of a progress icon.
- Watched time estimate on large file upload and checked that is relatively aligned with actual time remaining/taken.
- Checked UI looks as expected on both mobile and desktop.

## Screenshots
**Progress indicators**:
<img width="1024" height="717" alt="Image" src="https://github.com/user-attachments/assets/db8eb570-156d-4f26-863d-08987f57e62a" />

**Time remaining on hover/click**:
<img width="927" height="1024" alt="Image" src="https://github.com/user-attachments/assets/2f81346b-15c7-42d7-8765-69b39c32d6da" />


Closes #149 
Prioritised thanks to the support of @Felitendo via [BuyMeACoffee](https://buymeacoffee.com/smp46).
