### PR TITLE
feat(email): add option to set reply-to to creator's email

### DIFF
--- a/backend/prisma/seed/config.seed.ts
+++ b/backend/prisma/seed/config.seed.ts
@@ -198,6 +198,11 @@ export const configVariables = {
       defaultValue: "false",
       secret: false,
     },
+    shareRecipientsReplyToCreator: {
+      type: "boolean",
+      defaultValue: "false",
+      secret: false,
+    },
     shareDownloadNotificationSubject: {
       type: "string",
       defaultValue: "Your file was downloaded",

--- a/backend/src/email/email.service.ts
+++ b/backend/src/email/email.service.ts
@@ -38,23 +38,28 @@ export class EmailService {
     });
   }
 
-  private async sendMail(email: string, subject: string, text: string) {
-      const isHtml = this.config.get("email.sendHtmlEmails");
+  private async sendMail(
+    email: string,
+    subject: string,
+    text: string,
+    replyTo?: string,
+  ) {
+    const isHtml = this.config.get("email.sendHtmlEmails");
 
-      await this.getTransporter()
-        .sendMail({
-          from: `"${this.config.get("general.appName")}" <${this.config.get(
-            "smtp.email",
-          )}>`,
-          to: email,
-          subject: subject,
-          [isHtml ? "html" : "text"]: text,
-        })
-        .catch((e) => {
-          this.logger.error(e);
-          throw new InternalServerErrorException(this.i18n.t("email.sendFailed"));
-        });
-  
+    await this.getTransporter()
+      .sendMail({
+        from: `"${this.config.get("general.appName")}" <${this.config.get(
+          "smtp.email",
+        )}>`,
+        to: email,
+        subject: subject,
+        [isHtml ? "html" : "text"]: text,
+        ...(replyTo && { replyTo }),
+      })
+      .catch((e) => {
+        this.logger.error(e);
+        throw new InternalServerErrorException(this.i18n.t("email.sendFailed"));
+      });
   }
 
   async sendMailToShareRecipients(
@@ -76,6 +81,14 @@ export class EmailService {
     const lang = this.config.get("general.defaultLanguage");
     const locale = this.i18n.translate("email.locale", { lang });
 
+    let replyTo: string | undefined = undefined;
+    if (
+      this.config.get("email.shareRecipientsReplyToCreator") &&
+      creator?.email
+    ) {
+      replyTo = `"${creator.username}" <${creator.email}>`;
+    }
+
     await this.sendMail(
       recipientEmail,
       this.config.get("email.shareRecipientsSubject"),
@@ -85,7 +98,7 @@ export class EmailService {
         .replaceAll(
           "{creator}",
           creator?.username ??
-          this.i18n.t("email.shareRecipientsCreatorFallback"),
+            this.i18n.t("email.shareRecipientsCreatorFallback"),
         )
         .replaceAll("{creatorEmail}", creator?.email ?? "")
         .replaceAll("{shareUrl}", shareUrl)
@@ -99,6 +112,7 @@ export class EmailService {
             ? moment(expiration).locale(locale).fromNow()
             : this.i18n.t("email.shareRecipientsExpiresNeverFallback"),
         ),
+      replyTo,
     );
   }
 

--- a/backend/src/email/email.service.ts
+++ b/backend/src/email/email.service.ts
@@ -14,7 +14,7 @@ export class EmailService {
   constructor(
     private config: ConfigService,
     private readonly i18n: I18nService,
-  ) { }
+  ) {}
   private readonly logger = new Logger(EmailService.name);
 
   getTransporter() {

--- a/backend/src/share/share.service.ts
+++ b/backend/src/share/share.service.ts
@@ -165,7 +165,7 @@ export class ShareService {
         recipient.email,
         recipient.id,
         share.id,
-        share.creator,
+        share.creator || share.reverseShare?.creator,
         share.description,
         share.expiration,
       );

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -121,6 +121,8 @@ email:
     Pingvin Share 🐧
   #Whether to send an email to the share creator when an email recipient downloads a file. This requires SMTP and email recipient sharing.
   enableShareDownloadNotifications: "false"
+  #Whether to set the Reply-To header to the email address of the user who created the share.
+  shareRecipientsReplyToCreator: "false"
   #Subject of the email which gets sent to the share creator when a recipient downloads a file.
   shareDownloadNotificationSubject: Your file was downloaded
   #Message which gets sent to the share creator when a recipient downloads a file. Available variables:

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -561,6 +561,10 @@ export default {
   "admin.config.email.invite-message": "Invite message",
   "admin.config.email.invite-message.description":
     "Message which gets sent when an admin invites a user. {url} will be replaced with the invite URL, {email} with the email and {password} with the users password.",
+  "admin.config.email.share-recipients-reply-to-creator":
+    "Set Reply-To to creator's email",
+  "admin.config.email.share-recipients-reply-to-creator.description":
+  "Whether to set the Reply-To header to the email address of the user who created the share.",
   "admin.config.email.enable-share-download-notifications":
     "Enable download notifications",
   "admin.config.email.enable-share-download-notifications.description":


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

GitHub Copilot was used for autocomplete.

## What's new?
- The Administrator can toggle `Set Reply-To to creator's email` in the email configuration. When enabled, share related emails will contain the share creators email address in the `Reply-To` header. This allows the receiver to reply directly to the share creator.

## How has it been tested?
- Configured and enabled SMTP and Email sharing. Using mailpit for testing. Toggled the new setting then:
  - Created share, inserted generic email, email that was received in mailpit contains the administrator's username and email in the reply-to header.
  - Created share from a reverse share link, behaviour is the same (if logged in).
  - Created share anonymously from a reverse share link, the creator of the reverse share link is set in the Reply-To.

## Screenshots
<img width="1024" height="431" alt="Image" src="https://github.com/user-attachments/assets/af916aaf-4a62-49bc-8ad0-b247479c803d" />


Closes #157 
