### PR TITLE
fix(lang): dont set lang cookie from fallback value

### DIFF
--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -218,7 +218,9 @@ function App({ Component, pageProps }: AppProps) {
     if (!pageProps.language) return;
     const cookieLanguage = getCookie("language");
     if (!cookieLanguage) {
-      i18nUtil.setLanguageCookie(pageProps.language);
+      if (!pageProps.isConfigFallback) {
+        i18nUtil.setLanguageCookie(pageProps.language);
+      }
     } else if (pageProps.language !== cookieLanguage) {
       location.reload();
     }
@@ -227,7 +229,7 @@ function App({ Component, pageProps }: AppProps) {
 
     document.documentElement.dir = current.direction ?? "ltr";
     document.documentElement.lang = current.code;
-  }, [pageProps.language]);
+  }, [pageProps.language, pageProps.isConfigFallback]);
 
   useEffect(() => {
     const userColorPreference = userPreferences.get("colorScheme");
@@ -333,6 +335,7 @@ App.getInitialProps = async ({ ctx }: { ctx: GetServerSidePropsContext }) => {
     route?: string;
     colorScheme: ColorScheme;
     language?: string;
+    isConfigFallback?: boolean;
   } = {
     route: ctx.resolvedUrl,
     colorScheme:
@@ -357,6 +360,7 @@ App.getInitialProps = async ({ ctx }: { ctx: GetServerSidePropsContext }) => {
       ).data;
     } catch (e) {
       pageProps.configVariables = getDefaultConfig();
+      pageProps.isConfigFallback = true;
     }
 
     pageProps.route = ctx.req.url;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [ ] Yes
- [x] No


## What's new?
- Previously if the front-end was unable to retrieve the default language from the backend, then the default fallback language (en-US) was set as the user's language (using a cookie with a 1 year expiry). The result was even when the backend came online, the user's language will now be stuck on en-US.
  - Now if fallback language is used, the cookie is not set with a 1 year expiry. Upon next refresh, if the default backend language differs from the fallback language, the fallback language will be overridden.

## How has it been tested?
1. Set backend language to française in regular running instance.
2. Clear browser session
3. Kill the backend
4. Refresh page while frontend is still running, language will change to default of en-US
5. Restart backend
6. Refresh page and the language switched to française

Closes #163
