### PR TITLE
fix(share_id): underscores allowed everywhere ids are validated

### DIFF
--- a/backend/src/file/guard/fileSecurity.guard.ts
+++ b/backend/src/file/guard/fileSecurity.guard.ts
@@ -26,7 +26,7 @@ export class FileSecurityGuard extends ShareSecurityGuard {
   }
 
   isBase64(toCheck: string) {
-    const isBase64 = /^[a-zA-Z0-9-]*={0,2}$/.test(toCheck);
+    const isBase64 = /^[a-zA-Z0-9_-]*={0,2}$/.test(toCheck);
     return isBase64;
   }
 

--- a/backend/src/share/guard/shareIdValidation.guard.ts
+++ b/backend/src/share/guard/shareIdValidation.guard.ts
@@ -31,7 +31,7 @@ export class IdValidation implements CanActivate {
     }
 
     // Regular expression to check for Base64
-    const isBase64 = /^[a-zA-Z0-9-]*={0,2}$/.test(id);
+    const isBase64 = /^[a-zA-Z0-9_-]*={0,2}$/.test(id);
 
     if (!isBase64) {
       throw new BadRequestException(this.i18n.t("file.invalidIdFormat"));

--- a/backend/src/share/guard/shareOwner.guard.ts
+++ b/backend/src/share/guard/shareOwner.guard.ts
@@ -22,7 +22,7 @@ export class ShareOwnerGuard extends JwtGuard {
   }
 
   isBase64(toCheck: string) {
-    const isBase64 = /^[a-zA-Z0-9-]*={0,2}$/.test(toCheck);
+    const isBase64 = /^[a-zA-Z0-9_-]*={0,2}$/.test(toCheck);
     return isBase64;
   }
 

--- a/frontend/src/services/share.service.ts
+++ b/frontend/src/services/share.service.ts
@@ -13,7 +13,7 @@ import {
 import api from "./api.service";
 
 const isValidId = (id: string) => {
-  return /^[a-zA-Z0-9-]+$/.test(id);
+  return /^[a-zA-Z0-9_-]+$/.test(id);
 };
 
 const list = async (): Promise<MyShare[]> => {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

Gemini was used to quickly find everywhere Share ID validation occurs.

## What's new?
- Previously the frontend allowed inputting and submitting custom Share IDs with underscores, however everywhere else these were rejected. The result was trying to create a share with an underscore in the ID was silently rejected. Now underscores are allowed and work as expected.

## How has it been tested?
- Reproduced initial bug on latest stable release. Tried creating a share with ID “test_underscore”, it was silently rejected.
- After fixing ID validation: “test_underscore” was allowed and worked as expected.

Closes #167
