### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,6 @@ Pingvin Share X is a fork of [Pingvin Share](https://github.com/stonith404/pingv
 
 ## Setup
 
-### Managed hosting
-
-[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/pingvin-share)
-
-One-click managed Pingvin Share with storage, backups, email and a free subdomain included, and a share of every subscription goes back to the project.
-
 ### Installation with Docker (recommended)
 
 1. Download the `docker-compose.yml` file
@@ -61,6 +55,10 @@ To use the Beta channel:
 
 > [!IMPORTANT]
 > If you encounter any bugs, regressions, or have any other feedback while running the beta version, please [open a GitHub Issue](https://github.com/smp46/pingvin-share-x/issues). Please ensure you specify the exact version (including the beta tag).
+
+### Alternative Deployments
+
+Pingvin Share X can also be deployed through other platforms. For more information, see the [documentation](https://smp46.github.io/pingvin-share-x/setup/installation#alternative-deployments).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Pingvin Share X is a fork of [Pingvin Share](https://github.com/stonith404/pingv
 
 ## Setup
 
+### Managed hosting
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/pingvin-share)
+
+One-click managed Pingvin Share with storage, backups, email and a free subdomain included, and a share of every subscription goes back to the project.
+
 ### Installation with Docker (recommended)
 
 1. Download the `docker-compose.yml` file

--- a/docs/docs/setup/installation.md
+++ b/docs/docs/setup/installation.md
@@ -53,3 +53,17 @@ pm2 start npm --name "pingvin-share-x-frontend" -- run start
 **Uploading Large Files**: By default, Pingvin Share X uses a built-in reverse proxy to reduce the installation steps. However, this reverse proxy is not optimized for uploading large files. If you wish to upload larger files, you can either use the Docker installation or set up your own reverse proxy. An example configuration for Caddy can be found in `./reverse-proxy/Caddyfile`.
 
 The website is now listening on `http://localhost:3000`, have fun with Pingvin Share X!
+
+### Alternative Deployments
+
+Pingvin Share X can also be deployed via the following platforms:
+
+#### Zenith
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/pingvin-share)
+
+One-click managed Pingvin Share X.<br />
+DISCLAIMER: A portion of each subscription goes to the Pingvin Share X project.
+
+If you run a platform or know of a platform which supports deployments of Pingvin, please open a PR and it can be added here.
+

--- a/docs/docs/setup/installation.md
+++ b/docs/docs/setup/installation.md
@@ -60,7 +60,7 @@ Pingvin Share X can also be deployed via the following platforms:
 
 #### Zenith
 
-[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/pingvin-share)
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/pingvin-share-x)
 
 One-click managed Pingvin Share X.<br />
 DISCLAIMER: A portion of each subscription goes to the Pingvin Share X project.


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

used an assistant as a reference while finding the right readme section. the badge, link and wording are our standard ones and i've reviewed the six line diff myself.

## What's new?

hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we host Pingvin Share, so this PR adds a small "Deploy with Zenith" badge under a new Managed hosting heading in Setup (links to https://zenith.hosting/host/pingvin-share).

to be upfront: we currently run the upstream stonith404/pingvin-share v1.13.0 build, not your fork. since upstream is archived and you're the maintained continuation, we'd rather track your releases. happy to switch if you're up for it.

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

## How has it been tested?

n/a, docs only. i checked that the badge image and the link both resolve and that the section renders correctly.

## Screenshots

N/A

