### PR TITLE
feat: customise reverse share urls

### DIFF
--- a/backend/src/i18n/en-US/reverseShare.json
+++ b/backend/src/i18n/en-US/reverseShare.json
@@ -1,4 +1,5 @@
 {
   "notFound": "Reverse share token not found",
-  "maxShareSizeExceeded": "Max share size can't be greater than {maxSize} bytes."
+  "maxShareSizeExceeded": "Max share size can't be greater than {maxSize} bytes.",
+  "tokenInUse": "Reverse share token already in use"
 }

--- a/backend/src/reverseShare/dto/createReverseShare.dto.ts
+++ b/backend/src/reverseShare/dto/createReverseShare.dto.ts
@@ -1,4 +1,13 @@
-import { IsBoolean, IsString, Matches, Max, Min } from "class-validator";
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  Length,
+  Matches,
+  Max,
+  Min,
+} from "class-validator";
+import { i18nValidationMessage } from "nestjs-i18n";
 
 export class CreateReverseShareDTO {
   @IsBoolean()
@@ -22,4 +31,12 @@ export class CreateReverseShareDTO {
 
   @IsBoolean()
   publicAccess: boolean;
+
+  @IsString()
+  @IsOptional()
+  @Matches("^[a-zA-Z0-9_-]*$", undefined, {
+    message: i18nValidationMessage("validation.idPattern"),
+  })
+  @Length(3, 50)
+  token?: string;
 }

--- a/backend/src/reverseShare/dto/createReverseShare.dto.ts
+++ b/backend/src/reverseShare/dto/createReverseShare.dto.ts
@@ -34,7 +34,7 @@ export class CreateReverseShareDTO {
 
   @IsString()
   @IsOptional()
-  @Matches("^[a-zA-Z0-9_-]*$", undefined, {
+  @Matches("^[a-zA-Z0-9_-]+$", undefined, {
     message: i18nValidationMessage("validation.idPattern"),
   })
   @Length(3, 50)

--- a/backend/src/reverseShare/reverseShare.controller.ts
+++ b/backend/src/reverseShare/reverseShare.controller.ts
@@ -28,6 +28,17 @@ export class ReverseShareController {
     private readonly i18n: I18nService,
   ) {}
 
+  @Throttle({
+    default: {
+      limit: 10,
+      ttl: 60,
+    },
+  })
+  @Get("isReverseShareTokenAvailable/:token")
+  async isReverseShareTokenAvailable(@Param("token") token: string) {
+    return this.reverseShareService.isReverseShareTokenAvailable(token);
+  }
+
   @Post()
   @UseGuards(JwtGuard)
   async create(@Body() body: CreateReverseShareDTO, @GetUser() user: User) {

--- a/backend/src/reverseShare/reverseShare.controller.ts
+++ b/backend/src/reverseShare/reverseShare.controller.ts
@@ -28,6 +28,7 @@ export class ReverseShareController {
     private readonly i18n: I18nService,
   ) {}
 
+  @UseGuards(JwtGuard)
   @Throttle({
     default: {
       limit: 10,

--- a/backend/src/reverseShare/reverseShare.service.ts
+++ b/backend/src/reverseShare/reverseShare.service.ts
@@ -52,8 +52,15 @@ export class ReverseShareService {
         }),
       );
 
+    if (data.token) {
+      if (!(await this.isReverseShareTokenAvailable(data.token)).isAvailable) {
+        throw new BadRequestException(this.i18n.t("reverseShare.tokenInUse"));
+      }
+    }
+
     const reverseShare = await this.prisma.reverseShare.create({
       data: {
+        token: data.token || undefined,
         shareExpiration: expirationDate,
         remainingUses: data.maxUseCount,
         maxShareSize: data.maxShareSize,
@@ -65,6 +72,13 @@ export class ReverseShareService {
     });
 
     return reverseShare.token;
+  }
+
+  async isReverseShareTokenAvailable(token: string) {
+    const reverseShare = await this.prisma.reverseShare.findUnique({
+      where: { token },
+    });
+    return { isAvailable: !reverseShare };
   }
 
   async getByToken(reverseShareToken?: string) {

--- a/backend/src/reverseShare/reverseShare.service.ts
+++ b/backend/src/reverseShare/reverseShare.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable } from "@nestjs/common";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import * as moment from "moment";
 import { I18nService } from "nestjs-i18n";
 import { ConfigService } from "src/config/config.service";
@@ -58,20 +59,27 @@ export class ReverseShareService {
       }
     }
 
-    const reverseShare = await this.prisma.reverseShare.create({
-      data: {
-        token: data.token || undefined,
-        shareExpiration: expirationDate,
-        remainingUses: data.maxUseCount,
-        maxShareSize: data.maxShareSize,
-        sendEmailNotification: data.sendEmailNotification,
-        simplified: data.simplified,
-        publicAccess: data.publicAccess,
-        creatorId,
-      },
-    });
+    try {
+      const reverseShare = await this.prisma.reverseShare.create({
+        data: {
+          token: data.token || undefined,
+          shareExpiration: expirationDate,
+          remainingUses: data.maxUseCount,
+          maxShareSize: data.maxShareSize,
+          sendEmailNotification: data.sendEmailNotification,
+          simplified: data.simplified,
+          publicAccess: data.publicAccess,
+          creatorId,
+        },
+      });
 
-    return reverseShare.token;
+      return reverseShare.token;
+    } catch (e) {
+      if (e instanceof PrismaClientKnownRequestError && e.code === "P2002") {
+        throw new BadRequestException(this.i18n.t("reverseShare.tokenInUse"));
+      }
+      throw e;
+    }
   }
 
   async isReverseShareTokenAvailable(token: string) {

--- a/frontend/src/components/share/CustomUrlInput.tsx
+++ b/frontend/src/components/share/CustomUrlInput.tsx
@@ -1,0 +1,66 @@
+import { Button, Group, Text, TextInput } from "@mantine/core";
+import { UseFormReturnType } from "@mantine/form";
+import { FormattedMessage } from "react-intl";
+import useTranslate from "../../hooks/useTranslate.hook";
+import { generateShareId } from "../../utils/share.util";
+
+interface CustomUrlInputProps {
+  form: UseFormReturnType<any>;
+  fieldName?: string;
+  shareIdLength: number;
+  appUrl: string;
+  defaultAppUrl: string;
+  pathPrefix?: string;
+}
+
+const CustomUrlInput = ({
+  form,
+  fieldName = "link",
+  shareIdLength,
+  appUrl,
+  defaultAppUrl,
+  pathPrefix = "/s/",
+}: CustomUrlInputProps) => {
+  const t = useTranslate();
+  const fieldValue = form.values[fieldName] || "";
+  const hasError = !!form.errors[fieldName];
+
+  const baseUrl =
+    appUrl !== defaultAppUrl ? appUrl : typeof window !== "undefined" ? window.location.origin : "";
+
+  return (
+    <>
+      <Group align={hasError ? "center" : "flex-end"}>
+        <TextInput
+          style={{ flex: "1" }}
+          variant="filled"
+          label={t("upload.modal.link.label")}
+          placeholder="myAwesomeShare"
+          {...form.getInputProps(fieldName)}
+        />
+        <Button
+          style={{ flex: "0 0 auto" }}
+          variant="outline"
+          onClick={() =>
+            form.setFieldValue(fieldName, generateShareId(shareIdLength))
+          }
+        >
+          <FormattedMessage id="common.button.generate" />
+        </Button>
+      </Group>
+
+      <Text
+        truncate
+        italic
+        size="xs"
+        sx={(theme) => ({
+          color: theme.colors.gray[6],
+        })}
+      >
+        {`${baseUrl}${pathPrefix}${fieldValue}`}
+      </Text>
+    </>
+  );
+};
+
+export default CustomUrlInput;

--- a/frontend/src/components/share/CustomUrlInput.tsx
+++ b/frontend/src/components/share/CustomUrlInput.tsx
@@ -30,7 +30,7 @@ const CustomUrlInput = ({
 
   return (
     <>
-      <Group align={hasError ? "center" : "flex-end"}>
+      <Group align={hasError ? "center" : "flex-end"} noWrap>
         <TextInput
           style={{ flex: "1" }}
           variant="filled"
@@ -50,11 +50,11 @@ const CustomUrlInput = ({
       </Group>
 
       <Text
-        truncate
         italic
         size="xs"
         sx={(theme) => ({
           color: theme.colors.gray[6],
+          wordBreak: "break-all",
         })}
       >
         {`${baseUrl}${pathPrefix}${fieldValue}`}

--- a/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
+++ b/frontend/src/components/share/modals/showCreateReverseShareModal.tsx
@@ -23,8 +23,10 @@ import shareService from "../../../services/share.service";
 import { Timespan } from "../../../types/timespan.type";
 import { getExpirationPreview } from "../../../utils/date.util";
 import { byteToHumanSizeString } from "../../../utils/fileSize.util";
+import { generateShareId } from "../../../utils/share.util";
 import toast from "../../../utils/toast.util";
 import FileSizeInput from "../../core/FileSizeInput";
+import CustomUrlInput from "../CustomUrlInput";
 import showCompletedReverseShareModal from "./showCompletedReverseShareModal";
 
 const showCreateReverseShareModal = (
@@ -37,6 +39,7 @@ const showCreateReverseShareModal = (
   defaultAppUrl: string,
   maxShareSize: number,
   getReverseShares: () => void,
+  shareIdLength: number = 16,
 ) => {
   const t = translateOutsideContext();
 
@@ -52,6 +55,7 @@ const showCreateReverseShareModal = (
         appUrl={appUrl}
         defaultAppUrl={defaultAppUrl}
         maxShareSize={maxShareSize}
+        shareIdLength={shareIdLength}
       />
     ),
   });
@@ -66,6 +70,7 @@ const Body = ({
   appUrl,
   defaultAppUrl,
   maxShareSize,
+  shareIdLength = 16,
 }: {
   getReverseShares: () => void;
   showSendEmailNotificationOption: boolean;
@@ -75,11 +80,13 @@ const Body = ({
   appUrl: string;
   defaultAppUrl: string;
   maxShareSize: number;
+  shareIdLength?: number;
 }) => {
   const modals = useModals();
   const t = useTranslate();
 
   const userMaxShareSize = maxShareSize;
+  const generatedToken = generateShareId(shareIdLength);
 
   const defaultTimespan = defaultExpiration
     ? defaultExpiration
@@ -87,6 +94,7 @@ const Body = ({
 
   const form = useForm({
     initialValues: {
+      token: generatedToken,
       maxShareSize: userMaxShareSize,
       maxUseCount: 1,
       sendEmailNotification: false,
@@ -99,6 +107,14 @@ const Body = ({
     },
     validate: yupResolver(
       yup.object().shape({
+        token: yup
+          .string()
+          .required(t("common.error.field-required"))
+          .min(3, t("common.error.too-short", { length: 3 }))
+          .max(50, t("common.error.too-long", { length: 50 }))
+          .matches(new RegExp("^[a-zA-Z0-9_-]*$"), {
+            message: t("upload.modal.link.error.invalid"),
+          }),
         maxUseCount: yup
           .number()
           .typeError(t("common.error.invalid-number"))
@@ -120,6 +136,11 @@ const Body = ({
   });
 
   const onSubmit = form.onSubmit(async (values) => {
+    if (!(await shareService.isReverseShareTokenAvailable(values.token))) {
+      form.setFieldError("token", t("upload.modal.link.error.taken"));
+      return;
+    }
+
     // remember simplified and publicAccess in cookies
     setCookie("reverse-share.simplified", values.simplified);
     setCookie("reverse-share.public-access", values.publicAccess);
@@ -156,6 +177,7 @@ const Body = ({
         values.sendEmailNotification,
         values.simplified,
         values.publicAccess,
+        values.token,
       )
       .then(({ token }) => {
         modals.closeAll();
@@ -169,6 +191,14 @@ const Body = ({
     <Group>
       <form onSubmit={onSubmit}>
         <Stack align="stretch">
+          <CustomUrlInput
+            form={form}
+            fieldName="token"
+            shareIdLength={shareIdLength}
+            appUrl={appUrl}
+            defaultAppUrl={defaultAppUrl}
+            pathPrefix="/upload/"
+          />
           <div>
             <Grid align={form.errors.expiration_num ? "center" : "flex-end"}>
               <Col xs={6}>

--- a/frontend/src/components/upload/modals/showCreateUploadModal.tsx
+++ b/frontend/src/components/upload/modals/showCreateUploadModal.tsx
@@ -35,6 +35,8 @@ import {
 } from "../../../utils/date.util";
 import toast from "../../../utils/toast.util";
 import { Timespan } from "../../../types/timespan.type";
+import { generateShareId } from "../../../utils/share.util";
+import CustomUrlInput from "../../share/CustomUrlInput";
 
 const showCreateUploadModal = (
   modals: ModalsContextProps,
@@ -81,17 +83,7 @@ const showCreateUploadModal = (
   });
 };
 
-const generateShareId = (length: number = 16) => {
-  const chars =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  let result = "";
-  const randomArray = new Uint8Array(length >= 3 ? length : 3);
-  crypto.getRandomValues(randomArray);
-  randomArray.forEach((number) => {
-    result += chars[number % chars.length];
-  });
-  return result;
-};
+
 
 const generateAvailableLink = async (
   shareIdLength: number,
@@ -262,38 +254,14 @@ const CreateUploadModalBody = ({
       )}
       <form onSubmit={onSubmit}>
         <Stack align="stretch">
-          <Group align={form.errors.link ? "center" : "flex-end"}>
-            <TextInput
-              style={{ flex: "1" }}
-              variant="filled"
-              label={t("upload.modal.link.label")}
-              placeholder="myAwesomeShare"
-              {...form.getInputProps("link")}
-            />
-            <Button
-              style={{ flex: "0 0 auto" }}
-              variant="outline"
-              onClick={() =>
-                form.setFieldValue(
-                  "link",
-                  generateShareId(options.shareIdLength),
-                )
-              }
-            >
-              <FormattedMessage id="common.button.generate" />
-            </Button>
-          </Group>
-
-          <Text
-            truncate
-            italic
-            size="xs"
-            sx={(theme) => ({
-              color: theme.colors.gray[6],
-            })}
-          >
-            {`${options.appUrl !== options.defaultAppUrl ? options.appUrl : window.location.origin}/s/${form.values.link}`}
-          </Text>
+          <CustomUrlInput
+            form={form}
+            fieldName="link"
+            shareIdLength={options.shareIdLength}
+            appUrl={options.appUrl}
+            defaultAppUrl={options.defaultAppUrl}
+            pathPrefix="/s/"
+          />
           {!options.isReverseShare && (
             <>
               <Grid align={form.errors.expiration_num ? "center" : "flex-end"}>

--- a/frontend/src/pages/account/reverseShares.tsx
+++ b/frontend/src/pages/account/reverseShares.tsx
@@ -86,6 +86,7 @@ const MyShares = () => {
               defaultAppUrl,
               userMaxShareSize,
               getReverseShares,
+              config.get("share.shareIdLength"),
             )
           }
           leftIcon={<TbPlus size={20} />}

--- a/frontend/src/services/share.service.ts
+++ b/frontend/src/services/share.service.ts
@@ -1,5 +1,6 @@
 import { deleteCookie, setCookie } from "cookies-next";
 import mime from "mime-types";
+import { translateOutsideContext } from "../hooks/useTranslate.hook";
 import { FileUploadResponse } from "../types/File.type";
 
 import {
@@ -153,6 +154,12 @@ const uploadFile = async (
   ).data;
 };
 
+const isReverseShareTokenAvailable = async (token: string): Promise<boolean> => {
+  if (!isValidId(token))
+    throw new Error(translateOutsideContext()("upload.modal.link.error.invalid"));
+  return (await api.get(`/reverseShares/isReverseShareTokenAvailable/${token}`)).data.isAvailable;
+};
+
 const createReverseShare = async (
   shareExpiration: string,
   maxShareSize: number,
@@ -160,6 +167,7 @@ const createReverseShare = async (
   sendEmailNotification: boolean,
   simplified: boolean,
   publicAccess: boolean,
+  token?: string,
 ) => {
   return (
     await api.post("reverseShares", {
@@ -169,6 +177,7 @@ const createReverseShare = async (
       sendEmailNotification,
       simplified,
       publicAccess,
+      token,
     })
   ).data;
 };
@@ -179,7 +188,7 @@ const getMyReverseShares = async (): Promise<MyReverseShare[]> => {
 
 const setReverseShare = async (reverseShareToken: string) => {
   if (!isValidId(reverseShareToken))
-    throw new Error("Invalid Reverse Share Token");
+    throw new Error(translateOutsideContext()("upload.modal.link.error.invalid"));
   const { data } = await api.get(`/reverseShares/${reverseShareToken}`);
   setCookie("reverse_share_token", reverseShareToken);
   return data;
@@ -207,6 +216,7 @@ export default {
   getMyShares,
   getReceivedShares,
   isShareIdAvailable,
+  isReverseShareTokenAvailable,
   downloadFile,
   removeFile,
   uploadFile,

--- a/frontend/src/utils/share.util.ts
+++ b/frontend/src/utils/share.util.ts
@@ -1,0 +1,11 @@
+export const generateShareId = (length: number = 16) => {
+  const chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let result = "";
+  const randomArray = new Uint8Array(length >= 3 ? length : 3);
+  crypto.getRandomValues(randomArray);
+  randomArray.forEach((number) => {
+    result += chars[number % chars.length];
+  });
+  return result;
+};


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

Github Copilot was used for Autocomplete. Gemini was used for Code Review.

## What's new?
- When creating a reverse share, the url can now be customised just like a regular share
  -  By default, the reverse share url is still randomly generated with a length according to the default share ID length set by the admin.
  - Same criteria from regular share url customisation, URLs must be between 3-50 chars (inclusive), can only include letters, numbers, underscores and hyphens.
  - _code refactor_: to allow for this, the existing url customisation widget and code has been made into its own component, this component is now shared by both reverse share and regular share creation modals.

## How has it been tested?
- Customised a regular share url to ensure no regressions with the move to a component for url customisation.
- Tried creating a reverse share with an empty url, error code below url field showed it must be 3-50 chars.
- Tried creating a reverse share with spaces in the url, error showed accepted chars message.
- Tried creating a reverse share with a url of an existing reverse share, error showed duplicate links aren’t allowed.
- Tried creating a reverse share with >50 chars, error code showed the url must be 3-50 chars. The large url also wrapped correctly without breaking the modal.
- Tested on desktop on mobile to ensure UI is consistent.

## Screenshots
<img width="441" height="269" alt="Screenshot" src="https://github.com/user-attachments/assets/b2e70528-e024-4d15-a313-e635c36c8f91" />

Closes #114 
