### PR TITLE
fix(uploadPage): properly handle chromium file pickers, prevent hydration error

### DIFF
--- a/frontend/src/components/share/CustomUrlInput.tsx
+++ b/frontend/src/components/share/CustomUrlInput.tsx
@@ -1,5 +1,6 @@
 import { Button, Group, Text, TextInput } from "@mantine/core";
 import { UseFormReturnType } from "@mantine/form";
+import { useEffect, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import useTranslate from "../../hooks/useTranslate.hook";
 import { generateShareId } from "../../utils/share.util";
@@ -25,8 +26,14 @@ const CustomUrlInput = ({
   const fieldValue = form.values[fieldName] || "";
   const hasError = !!form.errors[fieldName];
 
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
   const baseUrl =
-    appUrl !== defaultAppUrl ? appUrl : typeof window !== "undefined" ? window.location.origin : "";
+    appUrl !== defaultAppUrl ? appUrl : isMounted ? window.location.origin : "";
 
   return (
     <>

--- a/frontend/src/components/upload/Dropzone.tsx
+++ b/frontend/src/components/upload/Dropzone.tsx
@@ -3,6 +3,7 @@ import { Dropzone as MantineDropzone } from "@mantine/dropzone";
 import React, { ForwardedRef, useRef } from "react";
 import { TbCloudUpload, TbUpload, TbFolder } from "react-icons/tb";
 import { FormattedMessage } from "react-intl";
+import { fromEvent } from "file-selector";
 import useTranslate from "../../hooks/useTranslate.hook";
 import { FileUpload } from "../../types/File.type";
 import { byteToHumanSizeString } from "../../utils/fileSize.util";
@@ -73,12 +74,21 @@ const traverseDirectory = async (entry: any, path = ""): Promise<File[]> => {
 };
 
 const getFilesFromEvent = async (event: any): Promise<any[]> => {
-  const items = event.dataTransfer ? event.dataTransfer.items : event.target.files;
-  if (!items) return [];
+  if (Array.isArray(event)) {
+    const filePromises = event.map(async (item: any) => {
+      if (item && typeof item.getFile === "function") {
+        return await item.getFile();
+      }
+      return item;
+    });
+    return await Promise.all(filePromises);
+  }
 
-  const filePromises: Promise<File[]>[] = [];
+  if (event?.dataTransfer) {
+    const items = event.dataTransfer.items;
+    if (!items) return [];
 
-  if (event.dataTransfer) {
+    const filePromises: Promise<File[]>[] = [];
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
       if (item.kind === "file") {
@@ -95,9 +105,13 @@ const getFilesFromEvent = async (event: any): Promise<any[]> => {
     }
     const fileArrays = await Promise.all(filePromises);
     return fileArrays.flat();
-  } else {
-    return Array.from(items) as File[];
   }
+
+  if (event?.target?.files) {
+    return Array.from(event.target.files) as File[];
+  }
+
+  return await fromEvent(event);
 };
 
 const Dropzone = ({

--- a/frontend/src/components/upload/Dropzone.tsx
+++ b/frontend/src/components/upload/Dropzone.tsx
@@ -1,6 +1,6 @@
 import { Button, Center, createStyles, Group, Text, Menu } from "@mantine/core";
 import { Dropzone as MantineDropzone } from "@mantine/dropzone";
-import React, { ForwardedRef, useRef } from "react";
+import React, { ForwardedRef, useEffect, useRef, useState } from "react";
 import { TbCloudUpload, TbUpload, TbFolder } from "react-icons/tb";
 import { FormattedMessage } from "react-intl";
 import { fromEvent } from "file-selector";
@@ -131,9 +131,14 @@ const Dropzone = ({
   const { classes } = useStyles();
   const openRef = useRef<() => void>();
   const folderInputRef = useRef<HTMLInputElement>(null);
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
 
   const isFolderUploadSupported =
-    typeof window !== "undefined" &&
+    isMounted &&
     typeof HTMLInputElement !== "undefined" &&
     "webkitdirectory" in HTMLInputElement.prototype;
 


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

Gemini was used for code review and to identify code that was causing the Chromium specific file handling errors.

## What's new?
- Unfortunately, the last update to support folder upload changed file picking behavior. Testing on Firefox and Webkit browsers was successful. However, Chromium APIs differ and weren’t considered/tested for specifically. File (and folder) picking now works as expected.
- Tangentially related: hydration errors from funky server side rendering on the upload page have been fixed as well, although these only showed in console and seemed to have no effect.


## How has it been tested?
- File upload by clicking on the dropzone, on Yandex and Chromium, previously wasn’t working. After commit 7f7dc72,  it now works and selects then uploads files as expected.
- File upload continues working as expected on Firefox and Webkit (Safari) browsers.
- Folder uploads continue working as expected on Firefox, Webkit and Chromium browsers.
- Hydration errors now no longer show in console on all browsers. The custom url component that was updated, works as expected on both regular share and reverse share creation.

Closes #175 
