### PR TITLE
feat: add admin notices for breaking changes

### DIFF
--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -5,6 +5,9 @@
   "compilerOptions": {
     "plugins": ["@nestjs/swagger"],
     "deleteOutDir": true,
-    "assets": [{ "include": "i18n/**/*", "watchAssets": true }]
+    "assets": [
+      { "include": "i18n/**/*", "watchAssets": true },
+      { "include": "adminNotice/**/*.json", "watchAssets": true }
+    ]
   }
 }

--- a/backend/src/adminNotice/admin-notices.json
+++ b/backend/src/adminNotice/admin-notices.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "s3_cors_update",
+    "title": "Action Required: Update S3 CORS Configuration",
+    "message": "This version introduces direct S3 uploads and downloads. You must update your S3 bucket's CORS configuration to support this.",
+    "conditionKey": "REQUIRE_S3_ENABLED",
+    "actionLink": "https://smp46.github.io/pingvin-share-x/setup/s3#cors-configuration"
+  }
+]

--- a/backend/src/adminNotice/adminNotice.controller.ts
+++ b/backend/src/adminNotice/adminNotice.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, Param, Post, Req, UseGuards } from "@nestjs/common";
+import { AdministratorGuard } from "src/auth/guard/isAdmin.guard";
+import { JwtGuard } from "src/auth/guard/jwt.guard";
+import { AdminNoticeService } from "./adminNotice.service";
+import { AdminNoticeDto } from "./dto/adminNotice.dto";
+
+@Controller("admin-notices")
+@UseGuards(JwtGuard, AdministratorGuard)
+export class AdminNoticeController {
+  constructor(private adminNoticeService: AdminNoticeService) {}
+
+  @Get("pending")
+  async getPendingNotices(): Promise<AdminNoticeDto[]> {
+    return this.adminNoticeService.getPendingNotices();
+  }
+
+  @Post(":id/dismiss")
+  async dismissNotice(
+    @Param("id") id: string,
+    @Req() req: any,
+  ): Promise<{ success: boolean }> {
+    await this.adminNoticeService.dismissNotice(id, req.user);
+    return { success: true };
+  }
+}

--- a/backend/src/adminNotice/adminNotice.module.ts
+++ b/backend/src/adminNotice/adminNotice.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "src/config/config.module";
+import { PrismaModule } from "src/prisma/prisma.module";
+import { AdminNoticeController } from "./adminNotice.controller";
+import { AdminNoticeService } from "./adminNotice.service";
+
+@Module({
+  imports: [ConfigModule, PrismaModule],
+  controllers: [AdminNoticeController],
+  providers: [AdminNoticeService],
+  exports: [AdminNoticeService],
+})
+export class AdminNoticeModule {}

--- a/backend/src/adminNotice/adminNotice.service.ts
+++ b/backend/src/adminNotice/adminNotice.service.ts
@@ -1,0 +1,108 @@
+import { Injectable, OnModuleInit } from "@nestjs/common";
+import { User } from "@prisma/client";
+import * as fs from "fs";
+import * as path from "path";
+import { ConfigService } from "src/config/config.service";
+import { PrismaService } from "src/prisma/prisma.service";
+import { AdminNoticeDto } from "./dto/adminNotice.dto";
+
+@Injectable()
+export class AdminNoticeService implements OnModuleInit {
+  private definitionsCache: AdminNoticeDto[] | null = null;
+
+  constructor(
+    private prisma: PrismaService,
+    private configService: ConfigService,
+  ) {}
+
+  onModuleInit() {
+    this.getNoticeDefinitions();
+  }
+
+  private getNoticeDefinitions(): AdminNoticeDto[] {
+    if (this.definitionsCache) {
+      return this.definitionsCache;
+    }
+
+    const candidatePaths = [
+      path.join(__dirname, "admin-notices.json"),
+      path.join(process.cwd(), "src/adminNotice/admin-notices.json"),
+      path.join(process.cwd(), "dist/adminNotice/admin-notices.json"),
+    ];
+
+    for (const filePath of candidatePaths) {
+      if (fs.existsSync(filePath)) {
+        try {
+          const fileContent = fs.readFileSync(filePath, "utf8");
+          this.definitionsCache = JSON.parse(fileContent);
+          return this.definitionsCache;
+        } catch {
+          // Ignore parse errors and try next path or fallback
+        }
+      }
+    }
+    this.definitionsCache = [];
+    return this.definitionsCache;
+  }
+
+  async getPendingNotices(): Promise<AdminNoticeDto[]> {
+    const records = await this.prisma.config.findMany({
+      where: { category: "admin_notices" },
+    });
+
+    const dismissedNoticeIds = new Set<string>();
+
+    for (const record of records) {
+      if (record.name === "dismissed" && record.value) {
+        try {
+          const legacyMap = JSON.parse(record.value);
+          Object.keys(legacyMap).forEach((id) => dismissedNoticeIds.add(id));
+        } catch {
+          // Ignore malformed JSON
+        }
+      } else if (record.name.startsWith("dismissed_")) {
+        dismissedNoticeIds.add(record.name.replace(/^dismissed_/, ""));
+      }
+    }
+
+    let isS3Enabled = false;
+    try {
+      isS3Enabled = !!this.configService.get("s3.enabled");
+    } catch {
+      isS3Enabled = false;
+    }
+
+    const allNotices = this.getNoticeDefinitions();
+
+    return allNotices.filter((notice) => {
+      if (dismissedNoticeIds.has(notice.id)) {
+        return false;
+      }
+      if (notice.conditionKey === "REQUIRE_S3_ENABLED" && !isS3Enabled) {
+        return false;
+      }
+      return true;
+    });
+  }
+
+  async dismissNotice(noticeId: string, user: User): Promise<void> {
+    const configName = `dismissed_${noticeId}`;
+    const value = JSON.stringify({
+      dismissedAt: new Date().toISOString(),
+      dismissedBy: user.id,
+      dismissedByUsername: user.username,
+    });
+
+    await this.prisma.config.upsert({
+      where: { name_category: { name: configName, category: "admin_notices" } },
+      update: { value },
+      create: {
+        name: configName,
+        category: "admin_notices",
+        type: "string",
+        value,
+        order: 0,
+      },
+    });
+  }
+}

--- a/backend/src/adminNotice/dto/adminNotice.dto.ts
+++ b/backend/src/adminNotice/dto/adminNotice.dto.ts
@@ -1,0 +1,7 @@
+export class AdminNoticeDto {
+  id: string;
+  title: string;
+  message: string;
+  conditionKey?: string;
+  actionLink?: string;
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -22,6 +22,7 @@ import { ReverseShareModule } from "./reverseShare/reverseShare.module";
 import { ShareModule } from "./share/share.module";
 import { UserModule } from "./user/user.module";
 import { SystemModule } from "./system/system.module";
+import { AdminNoticeModule } from "./adminNotice/adminNotice.module";
 
 import { SystemLanguageResolver } from "./i18n/systemLanguage.resolver";
 
@@ -40,6 +41,7 @@ const i18nPath = existsSync(join(__dirname, "../i18n"))
     JobsModule,
     UserModule,
     SystemModule,
+    AdminNoticeModule,
     ThrottlerModule.forRoot([
       {
         ttl: 60,

--- a/frontend/src/components/admin/AdminNoticeModal.tsx
+++ b/frontend/src/components/admin/AdminNoticeModal.tsx
@@ -1,0 +1,116 @@
+import {
+  Modal,
+  Text,
+  Checkbox,
+  Button,
+  Group,
+  Anchor,
+  Stack,
+  Badge,
+} from "@mantine/core";
+import { useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { TbAlertTriangle, TbExternalLink } from "react-icons/tb";
+
+export interface AdminNotice {
+  id: string;
+  title: string;
+  message: string;
+  actionLink?: string;
+}
+
+interface Props {
+  notice: AdminNotice | null;
+  onDismiss: (id: string) => Promise<void>;
+}
+
+export default function AdminNoticeModal({ notice, onDismiss }: Props) {
+  const intl = useIntl();
+  const [confirmed, setConfirmed] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  if (!notice) return null;
+
+  const handleConfirm = async () => {
+    setSubmitting(true);
+    try {
+      await onDismiss(notice.id);
+      setConfirmed(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      opened={!!notice}
+      onClose={() => {}}
+      withCloseButton={false}
+      closeOnClickOutside={false}
+      closeOnEscape={false}
+      title={
+        <Group spacing="xs">
+          <TbAlertTriangle color="red" size={24} />
+          <Badge color="red" variant="filled">
+            <FormattedMessage id="admin.notice.modal.headerTag" />
+          </Badge>
+        </Group>
+      }
+      centered
+      size="lg"
+    >
+      <Stack spacing="md">
+        <div>
+          <Text weight={700} size="lg" mb={4}>
+            {notice.title}
+          </Text>
+          <Text size="sm" color="dimmed">
+            {notice.message}
+          </Text>
+        </div>
+
+        {notice.actionLink && (
+          <Anchor
+            href={notice.actionLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            size="sm"
+          >
+            <Group spacing={4}>
+              <FormattedMessage id="admin.notice.modal.docsLink" />
+              <TbExternalLink size={14} />
+            </Group>
+          </Anchor>
+        )}
+
+        <Checkbox
+          checked={confirmed}
+          onChange={(e) => setConfirmed(e.currentTarget.checked)}
+          label={intl.formatMessage({
+            id: "admin.notice.modal.defaultCheckboxLabel",
+          })}
+          color="red"
+        />
+
+        <Text size="xs" color="dimmed" fs="italic">
+          <FormattedMessage id="admin.notice.modal.globalNoticeFooter" />
+        </Text>
+
+        <Group position="right" mt="xs">
+          <Button
+            color="red"
+            disabled={!confirmed}
+            loading={submitting}
+            onClick={handleConfirm}
+          >
+            {submitting ? (
+              <FormattedMessage id="admin.notice.modal.button.acknowledging" />
+            ) : (
+              <FormattedMessage id="admin.notice.modal.button.acknowledge" />
+            )}
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/frontend/src/i18n/translations/ar-EG.ts
+++ b/frontend/src/i18n/translations/ar-EG.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Must be at most {max}",
   "common.error.exact-length": "يجب أن يكون بالضبط {length} حرفًا",
   "common.error.invalid-number": "يجب أن يكون رقماً",
-  "common.error.field-required": "هذا الحقل مطلوب"
+  "common.error.field-required": "هذا الحقل مطلوب",
+
+  "admin.notice.modal.headerTag": "إجراء إداري مطلوب",
+  "admin.notice.modal.defaultCheckboxLabel": "أؤكد أنني قرأت هذا الإشعار وأفهم التغييرات الجذرية.",
+  "admin.notice.modal.button.acknowledge": "إقرار وتجاهل",
+  "admin.notice.modal.button.acknowledging": "جاري الإقرار...",
+  "admin.notice.modal.docsLink": "عرض الوثائق",
+  "admin.notice.modal.globalNoticeFooter": "ملاحظة: بمجرد الإقرار، سيتم إغلاق هذا الإشعار نهائيًا لجميع المسؤولين عبر جميع الأجهزة.",
 };

--- a/frontend/src/i18n/translations/bg-BG.ts
+++ b/frontend/src/i18n/translations/bg-BG.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Трябва да е максимум {max}",
   "common.error.exact-length": "Трябва да е точно {length} знака",
   "common.error.invalid-number": "Трябва да е число",
-  "common.error.field-required": "Това поле е задължително"
+  "common.error.field-required": "Това поле е задължително",
+
+  "admin.notice.modal.headerTag": "ИЗИСКВА СЕ АДМИНИСТРАТИВНО ДЕЙСТВИЕ",
+  "admin.notice.modal.defaultCheckboxLabel": "Потвърждавам, че прочетох това известие и разбирам съществените промени.",
+  "admin.notice.modal.button.acknowledge": "Потвърди и затвори",
+  "admin.notice.modal.button.acknowledging": "Потвърждаване...",
+  "admin.notice.modal.docsLink": "Преглед на документацията",
+  "admin.notice.modal.globalNoticeFooter": "Забележка: След като бъде потвърдено, това известие ще бъде премахнато завинаги за всички администратори на всички устройства.",
 };

--- a/frontend/src/i18n/translations/ca-ES.ts
+++ b/frontend/src/i18n/translations/ca-ES.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Ha de ser com a màxim {max}",
   "common.error.exact-length": "Ha de tenir exactament {length} caràcters",
   "common.error.invalid-number": "Ha de ser un número",
-  "common.error.field-required": "Aquest camp és obligatori"
+  "common.error.field-required": "Aquest camp és obligatori",
+
+  "admin.notice.modal.headerTag": "CAL UNA ACCIÓ ADMINISTRATIVA",
+  "admin.notice.modal.defaultCheckboxLabel": "Confirmo que he llegit aquest avís i entenc els canvis radicals.",
+  "admin.notice.modal.button.acknowledge": "Reconèixer i descartar",
+  "admin.notice.modal.button.acknowledging": "Reconeixent...",
+  "admin.notice.modal.docsLink": "Veure la documentació",
+  "admin.notice.modal.globalNoticeFooter": "Nota: Un cop reconegut, aquest avís es descartarà permanentment per a tots els administradors en tots els dispositius.",
 };

--- a/frontend/src/i18n/translations/cs-CZ.ts
+++ b/frontend/src/i18n/translations/cs-CZ.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Musí být nejvýše {max}",
   "common.error.exact-length": "Musí mít přesně {length} znaků",
   "common.error.invalid-number": "Musí být číslo",
-  "common.error.field-required": "Toto pole je povinné"
+  "common.error.field-required": "Toto pole je povinné",
+
+  "admin.notice.modal.headerTag": "VYŽADOVÁNA ADMINISTRATIVNÍ AKCE",
+  "admin.notice.modal.defaultCheckboxLabel": "Potvrzuji, že jsem si toto upozornění přečetl(a) a rozumím všem zásadním změnám.",
+  "admin.notice.modal.button.acknowledge": "Potvrdit a skrýt",
+  "admin.notice.modal.button.acknowledging": "Potvrzování...",
+  "admin.notice.modal.docsLink": "Zobrazit dokumentaci",
+  "admin.notice.modal.globalNoticeFooter": "Poznámka: Po potvrzení bude toto upozornění trvale skryto všem administrátorům na všech zařízeních.",
 };

--- a/frontend/src/i18n/translations/da-DK.ts
+++ b/frontend/src/i18n/translations/da-DK.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Must be at most {max}",
   "common.error.exact-length": "Skal være præcis {length} tegn",
   "common.error.invalid-number": "Skal være et tal",
-  "common.error.field-required": "Dette felt er påkrævet"
+  "common.error.field-required": "Dette felt er påkrævet",
+
+  "admin.notice.modal.headerTag": "ADMINISTRATIV HANDLING KRÆVES",
+  "admin.notice.modal.defaultCheckboxLabel": "Jeg bekræfter, at jeg har læst denne meddelelse og forstår de ændringer, der introduceres.",
+  "admin.notice.modal.button.acknowledge": "Bekræft og luk",
+  "admin.notice.modal.button.acknowledging": "Bekræfter...",
+  "admin.notice.modal.docsLink": "Se dokumentation",
+  "admin.notice.modal.globalNoticeFooter": "Bemærk: Når den er bekræftet, vil denne meddelelse blive fjernet permanent for alle administratorer på tværs af alle enheder.",
 };

--- a/frontend/src/i18n/translations/de-DE.ts
+++ b/frontend/src/i18n/translations/de-DE.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Darf höchstens {max} sein",
   "common.error.exact-length": "Muss genau {length} Zeichen lang sein",
   "common.error.invalid-number": "Muss eine Zahl sein",
-  "common.error.field-required": "Dieses Feld ist erforderlich"
+  "common.error.field-required": "Dieses Feld ist erforderlich",
+
+  "admin.notice.modal.headerTag": "ADMINISTRATIVE AKTION ERFORDERLICH",
+  "admin.notice.modal.defaultCheckboxLabel": "Ich bestätige, dass ich diesen Hinweis gelesen habe und die grundlegenden Änderungen verstehe.",
+  "admin.notice.modal.button.acknowledge": "Bestätigen & Schließen",
+  "admin.notice.modal.button.acknowledging": "Wird bestätigt...",
+  "admin.notice.modal.docsLink": "Dokumentation anzeigen",
+  "admin.notice.modal.globalNoticeFooter": "Hinweis: Nach der Bestätigung wird dieser Hinweis für alle Administratoren auf allen Geräten dauerhaft ausgeblendet.",
 };

--- a/frontend/src/i18n/translations/el-GR.ts
+++ b/frontend/src/i18n/translations/el-GR.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Must be at most {max}",
   "common.error.exact-length": "Πρέπει να αποτελείται ακριβώς από {length} χαρακτήρες",
   "common.error.invalid-number": "Πρέπει να είναι αριθμός",
-  "common.error.field-required": "Αυτό το πεδίο είναι υποχρεωτικό"
+  "common.error.field-required": "Αυτό το πεδίο είναι υποχρεωτικό",
+
+  "admin.notice.modal.headerTag": "ΑΠΑΙΤΕΙΤΑΙ ΔΙΑΧΕΙΡΙΣΤΙΚΗ ΕΝΕΡΓΕΙΑ",
+  "admin.notice.modal.defaultCheckboxLabel": "Επιβεβαιώνω ότι έχω διαβάσει αυτή την ειδοποίηση και κατανοώ τις ριζικές αλλαγές.",
+  "admin.notice.modal.button.acknowledge": "Επιβεβαίωση & Απόρριψη",
+  "admin.notice.modal.button.acknowledging": "Επιβεβαίωση...",
+  "admin.notice.modal.docsLink": "Προβολή τεκμηρίωσης",
+  "admin.notice.modal.globalNoticeFooter": "Σημείωση: Μόλις επιβεβαιωθεί, αυτή η ειδοποίηση θα απορριφθεί οριστικά για όλους τους διαχειριστές σε όλες τις συσκευές.",
 };

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -911,4 +911,11 @@ export default {
   "common.error.exact-length": "Must be exactly {length} characters",
   "common.error.invalid-number": "Must be a number",
   "common.error.field-required": "This field is required",
+
+  "admin.notice.modal.headerTag": "ADMINISTRATIVE ACTION REQUIRED",
+  "admin.notice.modal.defaultCheckboxLabel": "I confirm that I have read this notice and understand the breaking changes.",
+  "admin.notice.modal.button.acknowledge": "Acknowledge & Dismiss",
+  "admin.notice.modal.button.acknowledging": "Acknowledging...",
+  "admin.notice.modal.docsLink": "View Documentation",
+  "admin.notice.modal.globalNoticeFooter": "Note: Once acknowledged, this notice will be permanently dismissed for all administrators across all devices.",
 };

--- a/frontend/src/i18n/translations/es-ES.ts
+++ b/frontend/src/i18n/translations/es-ES.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Debe ser como máximo {max}",
   "common.error.exact-length": "Debe tener exactamente {length} caracteres",
   "common.error.invalid-number": "Debe ser un número",
-  "common.error.field-required": "Este campo es requerido"
+  "common.error.field-required": "Este campo es requerido",
+
+  "admin.notice.modal.headerTag": "ACCIÓN ADMINISTRATIVA REQUERIDA",
+  "admin.notice.modal.defaultCheckboxLabel": "Confirmo que he leído este aviso y entiendo los cambios disruptivos.",
+  "admin.notice.modal.button.acknowledge": "Confirmar y descartar",
+  "admin.notice.modal.button.acknowledging": "Confirmando...",
+  "admin.notice.modal.docsLink": "Ver documentación",
+  "admin.notice.modal.globalNoticeFooter": "Nota: Una vez confirmado, este aviso se descartará permanentemente para todos los administradores en todos los dispositivos.",
 };

--- a/frontend/src/i18n/translations/et-EE.ts
+++ b/frontend/src/i18n/translations/et-EE.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Peab olema maksimaalselt {max}",
   "common.error.exact-length": "Peab olema täpselt {length} tähemärki",
   "common.error.invalid-number": "Peab olema number",
-  "common.error.field-required": "See väli on kohustuslik"
+  "common.error.field-required": "See väli on kohustuslik",
+
+  "admin.notice.modal.headerTag": "NÕUTAV ADMINISTRATIIVNE TEGEVUS",
+  "admin.notice.modal.defaultCheckboxLabel": "Kinnitan, et olen seda teavitust lugenud ja mõistan katkestavaid muudatusi.",
+  "admin.notice.modal.button.acknowledge": "Kinnita ja sulge",
+  "admin.notice.modal.button.acknowledging": "Kinnitamine...",
+  "admin.notice.modal.docsLink": "Vaata dokumentatsiooni",
+  "admin.notice.modal.globalNoticeFooter": "Märkus: Pärast kinnitamist eemaldatakse see teavitus jäädavalt kõigi administraatorite jaoks kõigis seadmetes.",
 };

--- a/frontend/src/i18n/translations/fa-IR.ts
+++ b/frontend/src/i18n/translations/fa-IR.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "باید حداکثر {max} باشد",
   "common.error.exact-length": "باید دقیقاً {length} کاراکتر باشد",
   "common.error.invalid-number": "باید یک عدد باشد",
-  "common.error.field-required": "این فیلد الزامی است"
+  "common.error.field-required": "این فیلد الزامی است",
+
+  "admin.notice.modal.headerTag": "اقدام مدیریتی لازم است",
+  "admin.notice.modal.defaultCheckboxLabel": "تایید می‌کنم که این اطلاعیه را خوانده‌ام و تغییرات بنیادی را درک می‌کنم.",
+  "admin.notice.modal.button.acknowledge": "تایید و بستن",
+  "admin.notice.modal.button.acknowledging": "در حال تایید...",
+  "admin.notice.modal.docsLink": "مشاهده مستندات",
+  "admin.notice.modal.globalNoticeFooter": "توجه: پس از تایید، این اطلاعیه برای همه مدیران در تمام دستگاه‌ها به طور دائمی بسته خواهد شد.",
 };

--- a/frontend/src/i18n/translations/fi-FI.ts
+++ b/frontend/src/i18n/translations/fi-FI.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Must be at most {max}",
   "common.error.exact-length": "On oltava tarkasti {length} merkkiä pitkä",
   "common.error.invalid-number": "Pitää olla luku",
-  "common.error.field-required": "Tämä kenttä on pakollinen"
+  "common.error.field-required": "Tämä kenttä on pakollinen",
+
+  "admin.notice.modal.headerTag": "VAATII YLLÄPIDON TOIMENPITEITÄ",
+  "admin.notice.modal.defaultCheckboxLabel": "Vahvistan lukeneeni tämän ilmoituksen ja ymmärtäväni kriittiset muutokset.",
+  "admin.notice.modal.button.acknowledge": "Vahvista ja sulje",
+  "admin.notice.modal.button.acknowledging": "Vahvistetaan...",
+  "admin.notice.modal.docsLink": "Näytä dokumentaatio",
+  "admin.notice.modal.globalNoticeFooter": "Huomautus: Kun tämä ilmoitus on vahvistettu, se poistetaan pysyvästi kaikilta ylläpitäjiltä kaikilla laitteilla.",
 };

--- a/frontend/src/i18n/translations/fr-FR.ts
+++ b/frontend/src/i18n/translations/fr-FR.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Doit être au plus {max}",
   "common.error.exact-length": "Doit comporter exactement {length} caractères",
   "common.error.invalid-number": "Doit être un nombre",
-  "common.error.field-required": "Ce champ est obligatoire"
+  "common.error.field-required": "Ce champ est obligatoire",
+
+  "admin.notice.modal.headerTag": "ACTION ADMINISTRATIVE REQUISE",
+  "admin.notice.modal.defaultCheckboxLabel": "Je confirme avoir lu cet avertissement et comprendre les changements majeurs.",
+  "admin.notice.modal.button.acknowledge": "Confirmer et ignorer",
+  "admin.notice.modal.button.acknowledging": "Confirmation...",
+  "admin.notice.modal.docsLink": "Voir la documentation",
+  "admin.notice.modal.globalNoticeFooter": "Remarque : Une fois confirmé, cet avertissement sera définitivement masqué pour tous les administrateurs sur tous les appareils.",
 };

--- a/frontend/src/i18n/translations/hr-HR.ts
+++ b/frontend/src/i18n/translations/hr-HR.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Mora biti najviše {max}",
   "common.error.exact-length": "Mora imati točno {length} znakova",
   "common.error.invalid-number": "Mora biti broj",
-  "common.error.field-required": "Polje je obavezno"
+  "common.error.field-required": "Polje je obavezno",
+
+  "admin.notice.modal.headerTag": "POTREBNA JE ADMINISTRATIVNA AKCIJA",
+  "admin.notice.modal.defaultCheckboxLabel": "Potvrđujem da sam pročitao/la ovu obavijest i razumijem ključne promjene.",
+  "admin.notice.modal.button.acknowledge": "Potvrdi i zatvori",
+  "admin.notice.modal.button.acknowledging": "Potvrđivanje...",
+  "admin.notice.modal.docsLink": "Prikaži dokumentaciju",
+  "admin.notice.modal.globalNoticeFooter": "Napomena: Nakon što se potvrdi, ova će obavijest biti trajno uklonjena za sve administratore na svim uređajima.",
 };

--- a/frontend/src/i18n/translations/hu-HU.ts
+++ b/frontend/src/i18n/translations/hu-HU.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Legfeljebb {max} értéket lehet megadni",
   "common.error.exact-length": "Pontosan {length} karakter szükséges",
   "common.error.invalid-number": "Számot kell megadnia",
-  "common.error.field-required": "Ez egy kötelező mező"
+  "common.error.field-required": "Ez egy kötelező mező",
+
+  "admin.notice.modal.headerTag": "ADMINISZTRÁTORI INTÉZKEDÉS SZÜKSÉGES",
+  "admin.notice.modal.defaultCheckboxLabel": "Megerősítem, hogy elolvastam ezt az értesítést, és megértettem a lényegi változtatásokat.",
+  "admin.notice.modal.button.acknowledge": "Tudomásul veszem és bezárom",
+  "admin.notice.modal.button.acknowledging": "Feldolgozás...",
+  "admin.notice.modal.docsLink": "Dokumentáció megtekintése",
+  "admin.notice.modal.globalNoticeFooter": "Megjegyzés: A tudomásulvételt követően ez az értesítés minden adminisztrátor számára véglegesen elrejtésre kerül az összes eszközön.",
 };

--- a/frontend/src/i18n/translations/it-IT.ts
+++ b/frontend/src/i18n/translations/it-IT.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Deve essere al massimo {max}",
   "common.error.exact-length": "Deve essere esattamente {length} caratteri",
   "common.error.invalid-number": "Deve essere un numero",
-  "common.error.field-required": "Questo campo è obbligatorio"
+  "common.error.field-required": "Questo campo è obbligatorio",
+
+  "admin.notice.modal.headerTag": "AZIONE AMMINISTRATIVA RICHIESTA",
+  "admin.notice.modal.defaultCheckboxLabel": "Confermo di aver letto questo avviso e di aver compreso le modifiche sostanziali.",
+  "admin.notice.modal.button.acknowledge": "Conferma e chiudi",
+  "admin.notice.modal.button.acknowledging": "Conferma in corso...",
+  "admin.notice.modal.docsLink": "Visualizza la documentazione",
+  "admin.notice.modal.globalNoticeFooter": "Nota: Una volta confermato, questo avviso verrà rimosso definitivamente per tutti gli amministratori su tutti i dispositivi.",
 };

--- a/frontend/src/i18n/translations/ja-JP.ts
+++ b/frontend/src/i18n/translations/ja-JP.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "最大で{max} である必要があります",
   "common.error.exact-length": "{length} 文字である必要があります",
   "common.error.invalid-number": "数字でなければなりません",
-  "common.error.field-required": "これは必須項目です"
+  "common.error.field-required": "これは必須項目です",
+
+  "admin.notice.modal.headerTag": "管理者による対応が必要です",
+  "admin.notice.modal.defaultCheckboxLabel": "この通知を確認し、互換性に影響する変更を理解したことを確認します。",
+  "admin.notice.modal.button.acknowledge": "確認して閉じる",
+  "admin.notice.modal.button.acknowledging": "確認中...",
+  "admin.notice.modal.docsLink": "ドキュメントを表示",
+  "admin.notice.modal.globalNoticeFooter": "注: 一度確認すると、この通知はすべてのデバイスのすべての管理者に対して永久に非表示になります。",
 };

--- a/frontend/src/i18n/translations/ko-KR.ts
+++ b/frontend/src/i18n/translations/ko-KR.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Must be at most {max}",
   "common.error.exact-length": "{length} 자 이어야 합니다.",
   "common.error.invalid-number": "숫자만 가능합니다.",
-  "common.error.field-required": "이 필드는 필수입니다"
+  "common.error.field-required": "이 필드는 필수입니다",
+
+  "admin.notice.modal.headerTag": "관리자 조치 필요",
+  "admin.notice.modal.defaultCheckboxLabel": "이 공지 사항을 읽었으며 호환성을 깨뜨리는 변경 사항을 이해했음을 확인합니다.",
+  "admin.notice.modal.button.acknowledge": "확인 및 닫기",
+  "admin.notice.modal.button.acknowledging": "확인 중...",
+  "admin.notice.modal.docsLink": "문서 보기",
+  "admin.notice.modal.globalNoticeFooter": "참고: 일단 확인하면 이 공지 사항은 모든 기기의 모든 관리자에 대해 영구적으로 닫힙니다.",
 };

--- a/frontend/src/i18n/translations/nl-BE.ts
+++ b/frontend/src/i18n/translations/nl-BE.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Mag maximaal {max} zijn",
   "common.error.exact-length": "Moet precies {length} tekens bevatten",
   "common.error.invalid-number": "Moet een getal zijn",
-  "common.error.field-required": "Dit veld is verplicht"
+  "common.error.field-required": "Dit veld is verplicht",
+
+  "admin.notice.modal.headerTag": "ADMINISTRATIEVE ACTIE VEREIST",
+  "admin.notice.modal.defaultCheckboxLabel": "Ik bevestig dat ik deze melding heb gelezen en de ingrijpende wijzigingen begrijp.",
+  "admin.notice.modal.button.acknowledge": "Bevestigen en sluiten",
+  "admin.notice.modal.button.acknowledging": "Bevestigen...",
+  "admin.notice.modal.docsLink": "Documentatie bekijken",
+  "admin.notice.modal.globalNoticeFooter": "Opmerking: Zodra dit is bevestigd, wordt deze melding permanent verborgen voor alle beheerders op alle apparaten.",
 };

--- a/frontend/src/i18n/translations/no-NO.ts
+++ b/frontend/src/i18n/translations/no-NO.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Må være maksimalt {max}",
   "common.error.exact-length": "Må være nøyaktig {length} tegn",
   "common.error.invalid-number": "Må være et tall",
-  "common.error.field-required": "Dette feltet er obligatorisk"
+  "common.error.field-required": "Dette feltet er obligatorisk",
+
+  "admin.notice.modal.headerTag": "ADMINISTRATIV HANDLING KREVES",
+  "admin.notice.modal.defaultCheckboxLabel": "Jeg bekrefter at jeg har lest denne meldingen og forstår de omfattende endringene.",
+  "admin.notice.modal.button.acknowledge": "Bekreft og lukk",
+  "admin.notice.modal.button.acknowledging": "Bekrefter...",
+  "admin.notice.modal.docsLink": "Se dokumentasjon",
+  "admin.notice.modal.globalNoticeFooter": "Merk: Når den er bekræftet, vil denne meldingen bli permanent fjernet for alle administratorer på tvers av alle enheter.",
 };

--- a/frontend/src/i18n/translations/pl-PL.ts
+++ b/frontend/src/i18n/translations/pl-PL.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Musi wynosić co najwyżej {max}",
   "common.error.exact-length": "Musi mieć dokładnie {length} znaków",
   "common.error.invalid-number": "Musi być liczbą",
-  "common.error.field-required": "To pole jest wymagane"
+  "common.error.field-required": "To pole jest wymagane",
+
+  "admin.notice.modal.headerTag": "WYMAGANE DZIAŁANIE ADMINISTRACYJNE",
+  "admin.notice.modal.defaultCheckboxLabel": "Potwierdzam, że przeczytałem(am) to powiadomienie i rozumiem wprowadzane zmiany.",
+  "admin.notice.modal.button.acknowledge": "Potwierdź i odrzuć",
+  "admin.notice.modal.button.acknowledging": "Potwierdzanie...",
+  "admin.notice.modal.docsLink": "Zobacz dokumentację",
+  "admin.notice.modal.globalNoticeFooter": "Uwaga: Po potwierdzeniu to powiadomienie zostanie trwale usunięte dla wszystkich administratorów na wszystkich urządzeniach.",
 };

--- a/frontend/src/i18n/translations/pt-BR.ts
+++ b/frontend/src/i18n/translations/pt-BR.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Deve ser no máximo {max}",
   "common.error.exact-length": "Deve ter exatamente {length} caracteres",
   "common.error.invalid-number": "Tem que ser um número",
-  "common.error.field-required": "Este campo é obrigatório"
+  "common.error.field-required": "Este campo é obrigatório",
+
+  "admin.notice.modal.headerTag": "AÇÃO ADMINISTRATIVA NECESSÁRIA",
+  "admin.notice.modal.defaultCheckboxLabel": "Confirmo que li este aviso e entendo as alterações de compatibilidade.",
+  "admin.notice.modal.button.acknowledge": "Confirmar e dispensar",
+  "admin.notice.modal.button.acknowledging": "Confirmando...",
+  "admin.notice.modal.docsLink": "Ver documentação",
+  "admin.notice.modal.globalNoticeFooter": "Nota: Uma vez confirmado, este aviso será permanentemente dispensado para todos os administradores em todos os dispositivos.",
 };

--- a/frontend/src/i18n/translations/ru-RU.ts
+++ b/frontend/src/i18n/translations/ru-RU.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Должно быть не больше {max}",
   "common.error.exact-length": "Должно быть ровно {length} символов",
   "common.error.invalid-number": "Должно быть числом",
-  "common.error.field-required": "Поле обязательно для заполнения"
+  "common.error.field-required": "Поле обязательно для заполнения",
+
+  "admin.notice.modal.headerTag": "ТРЕБУЕТСЯ ДЕЙСТВИЕ АДМИНИСТРАТОРА",
+  "admin.notice.modal.defaultCheckboxLabel": "Я подтверждаю, что прочитал(а) это уведомление и понимаю критические изменения.",
+  "admin.notice.modal.button.acknowledge": "Подтвердить и закрыть",
+  "admin.notice.modal.button.acknowledging": "Подтверждение...",
+  "admin.notice.modal.docsLink": "Просмотреть документацию",
+  "admin.notice.modal.globalNoticeFooter": "Примечание: После подтверждения это уведомление будет навсегда скрыто для всех администраторов на всех устройствах.",
 };

--- a/frontend/src/i18n/translations/sl-SI.ts
+++ b/frontend/src/i18n/translations/sl-SI.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Must be at most {max}",
   "common.error.exact-length": "Dolžina mora biti točno {length} znakov",
   "common.error.invalid-number": "Mora biti številka",
-  "common.error.field-required": "To polje je obvezno"
+  "common.error.field-required": "To polje je obvezno",
+
+  "admin.notice.modal.headerTag": "ZAHTEVANO JE ADMINISTRATIVNO DEJANJE",
+  "admin.notice.modal.defaultCheckboxLabel": "Potrjujem, da sem prebral/a to obvestilo in razumem bistvene spremembe.",
+  "admin.notice.modal.button.acknowledge": "Potrdi in zapri",
+  "admin.notice.modal.button.acknowledging": "Potrjevanje...",
+  "admin.notice.modal.docsLink": "Ogled dokumentacije",
+  "admin.notice.modal.globalNoticeFooter": "Opomba: Ko je obvestilo potrjeno, bo trajno odstranjeno za vse administratorje na vseh napravah.",
 };

--- a/frontend/src/i18n/translations/sr-CS.ts
+++ b/frontend/src/i18n/translations/sr-CS.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Mora biti najviše {max}",
   "common.error.exact-length": "Mora da ima tačno {length} znakova",
   "common.error.invalid-number": "Mora biti broj",
-  "common.error.field-required": "Polje je obavezno"
+  "common.error.field-required": "Polje je obavezno",
+
+  "admin.notice.modal.headerTag": "POTREBNA JE ADMINISTRATIVNA AKCIJA",
+  "admin.notice.modal.defaultCheckboxLabel": "Potvrđujem da sam pročitao/la ovo obaveštenje i razumem ključne promene.",
+  "admin.notice.modal.button.acknowledge": "Potvrdi i zatvori",
+  "admin.notice.modal.button.acknowledging": "Potvrđivanje...",
+  "admin.notice.modal.docsLink": "Prikaži dokumentaciju",
+  "admin.notice.modal.globalNoticeFooter": "Napomena: Nakon što se potvrdi, ovo obaveštenje će biti trajno uklonjeno za sve administratore na svim uređajima.",
 };

--- a/frontend/src/i18n/translations/sr-SP.ts
+++ b/frontend/src/i18n/translations/sr-SP.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Мора бити највише {max}",
   "common.error.exact-length": "Мора да има тачно {length} знакова",
   "common.error.invalid-number": "Мора бити број",
-  "common.error.field-required": "Поље је обавезно"
+  "common.error.field-required": "Поље је обавезно",
+
+  "admin.notice.modal.headerTag": "ПОТРЕБНА ЈЕ АДМИНИСТРАТИВНА АКЦИЈА",
+  "admin.notice.modal.defaultCheckboxLabel": "Потврђујем да сам прочитао/ла ово обавештење и разумем кључне промене.",
+  "admin.notice.modal.button.acknowledge": "Потврди и затвори",
+  "admin.notice.modal.button.acknowledging": "Потврђивање...",
+  "admin.notice.modal.docsLink": "Прикажи документацију",
+  "admin.notice.modal.globalNoticeFooter": "Напомена: Након што се потврди, ово обавештење ће бити трајно уклоњено за све администраторе на свим уређајима.",
 };

--- a/frontend/src/i18n/translations/sv-SE.ts
+++ b/frontend/src/i18n/translations/sv-SE.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Måste vara som mest {max}",
   "common.error.exact-length": "Måste vara exakt {length} tecken långt",
   "common.error.invalid-number": "Måste vara ett tal",
-  "common.error.field-required": "Obligatoriskt fält"
+  "common.error.field-required": "Obligatoriskt fält",
+
+  "admin.notice.modal.headerTag": "ADMINISTRATIV ÅTGÄRD KRÄVS",
+  "admin.notice.modal.defaultCheckboxLabel": "Jag bekräftar att jag har läst detta meddelande och förstår de genomgripande ändringarna.",
+  "admin.notice.modal.button.acknowledge": "Bekräfta och stäng",
+  "admin.notice.modal.button.acknowledging": "Bekräftar...",
+  "admin.notice.modal.docsLink": "Visa dokumentation",
+  "admin.notice.modal.globalNoticeFooter": "Obs: När det har bekräftats kommer detta meddelande att tas bort permanent för alla administratörer på alla enheter.",
 };

--- a/frontend/src/i18n/translations/th-TH.ts
+++ b/frontend/src/i18n/translations/th-TH.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Must be at most {max}",
   "common.error.exact-length": "ต้องมีความยาว {length} ตัวอักษร",
   "common.error.invalid-number": "ต้องเป็นตัวเลข",
-  "common.error.field-required": "ต้องกรอกข้อมูลนี้"
+  "common.error.field-required": "ต้องกรอกข้อมูลนี้",
+
+  "admin.notice.modal.headerTag": "จำเป็นต้องดำเนินการโดยผู้ดูแลระบบ",
+  "admin.notice.modal.defaultCheckboxLabel": "ฉันยืนยันว่าได้อ่านประกาศนี้และเข้าใจการเปลี่ยนแปลงที่สำคัญแล้ว",
+  "admin.notice.modal.button.acknowledge": "รับทราบและปิด",
+  "admin.notice.modal.button.acknowledging": "กำลังรับทราบ...",
+  "admin.notice.modal.docsLink": "ดูเอกสารประกอบ",
+  "admin.notice.modal.globalNoticeFooter": "หมายเหตุ: เมื่อรับทราบแล้ว ประกาศนี้จะถูกปิดอย่างถาวรสำหรับผู้ดูแลระบบทุกคนในทุกอุปกรณ์",
 };

--- a/frontend/src/i18n/translations/tr-TR.ts
+++ b/frontend/src/i18n/translations/tr-TR.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "En fazla {max} olabilir",
   "common.error.exact-length": "Tam olarak {length} karakter olmalıdır",
   "common.error.invalid-number": "Bir sayı olmalıdır",
-  "common.error.field-required": "Bu alan gereklidir"
+  "common.error.field-required": "Bu alan gereklidir",
+
+  "admin.notice.modal.headerTag": "YÖNETİCİ EYLEMİ GEREKLİ",
+  "admin.notice.modal.defaultCheckboxLabel": "Bu bildirimi okuduğumu ve köklü değişiklikleri anladığımı onaylıyorum.",
+  "admin.notice.modal.button.acknowledge": "Onayla ve Kapat",
+  "admin.notice.modal.button.acknowledging": "Onaylanıyor...",
+  "admin.notice.modal.docsLink": "Dokümantasyonu Görüntüle",
+  "admin.notice.modal.globalNoticeFooter": "Not: Onaylandıktan sonra bu bildirim, tüm cihazlardaki tüm yöneticiler için kalıcı olarak kapatılacaktır.",
 };

--- a/frontend/src/i18n/translations/uk-UA.ts
+++ b/frontend/src/i18n/translations/uk-UA.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Повинно бути не більше ніж {max}",
   "common.error.exact-length": "Повинно бути рівно {length} символів",
   "common.error.invalid-number": "Повинно бути числом",
-  "common.error.field-required": "Поле обов'язкове для заповнення"
+  "common.error.field-required": "Поле обов'язкове для заповнення",
+
+  "admin.notice.modal.headerTag": "ПОТРІБНА ДІЯ АДМІНІСТРАТОРА",
+  "admin.notice.modal.defaultCheckboxLabel": "Я підтверджую, що прочитав(ла) це сповіщення та розумію критичні зміни.",
+  "admin.notice.modal.button.acknowledge": "Підтвердити та закрити",
+  "admin.notice.modal.button.acknowledging": "Підтвердження...",
+  "admin.notice.modal.docsLink": "Переглянути документацію",
+  "admin.notice.modal.globalNoticeFooter": "Примітка: Після підтвердження це сповіщення буде назавжди приховано для всіх адміністраторів на всіх пристроях.",
 };

--- a/frontend/src/i18n/translations/vi-VN.ts
+++ b/frontend/src/i18n/translations/vi-VN.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "Must be at most {max}",
   "common.error.exact-length": "Bằng {length} kí tự",
   "common.error.invalid-number": "Phải là số",
-  "common.error.field-required": "Trường bắt buộc"
+  "common.error.field-required": "Trường bắt buộc",
+
+  "admin.notice.modal.headerTag": "YÊU CẦU THAO TÁC QUẢN TRỊ",
+  "admin.notice.modal.defaultCheckboxLabel": "Tôi xác nhận đã đọc thông báo này và hiểu các thay đổi quan trọng.",
+  "admin.notice.modal.button.acknowledge": "Xác nhận & Đóng",
+  "admin.notice.modal.button.acknowledging": "Đang xác nhận...",
+  "admin.notice.modal.docsLink": "Xem tài liệu hướng dẫn",
+  "admin.notice.modal.globalNoticeFooter": "Lưu ý: Sau khi xác nhận, thông báo này sẽ bị ẩn vĩnh viễn đối với tất cả quản trị viên trên mọi thiết bị.",
 };

--- a/frontend/src/i18n/translations/zh-CN.ts
+++ b/frontend/src/i18n/translations/zh-CN.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "必须至多为 {max}",
   "common.error.exact-length": "必须为 {length} 个字符",
   "common.error.invalid-number": "必须为数字",
-  "common.error.field-required": "必填项"
+  "common.error.field-required": "必填项",
+
+  "admin.notice.modal.headerTag": "需要管理员操作",
+  "admin.notice.modal.defaultCheckboxLabel": "我确认已阅读此通知并理解重大变更。",
+  "admin.notice.modal.button.acknowledge": "确认并关闭",
+  "admin.notice.modal.button.acknowledging": "正在确认...",
+  "admin.notice.modal.docsLink": "查看文档",
+  "admin.notice.modal.globalNoticeFooter": "注意：一旦确认，此通知将在所有设备上对所有管理员永久关闭。",
 };

--- a/frontend/src/i18n/translations/zh-TW.ts
+++ b/frontend/src/i18n/translations/zh-TW.ts
@@ -644,5 +644,12 @@ export default {
   "common.error.number-too-large": "必須小於 {max}",
   "common.error.exact-length": "必須為 {length} 個字元",
   "common.error.invalid-number": "必須為數字",
-  "common.error.field-required": "必填"
+  "common.error.field-required": "必填",
+
+  "admin.notice.modal.headerTag": "需要管理員操作",
+  "admin.notice.modal.defaultCheckboxLabel": "我確認已閱讀此通知並理解重大變更。",
+  "admin.notice.modal.button.acknowledge": "確認並關閉",
+  "admin.notice.modal.button.acknowledging": "正在確認...",
+  "admin.notice.modal.docsLink": "檢視文件",
+  "admin.notice.modal.globalNoticeFooter": "注意：一旦確認，此通知將在所有裝置上對所有管理員永久關閉。",
 };

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -34,6 +34,8 @@ import i18nUtil from "../utils/i18n.util";
 import userPreferences from "../utils/userPreferences.util";
 import Footer from "../components/footer/Footer";
 import { getDefaultConfig } from "../utils/defaultConfig.util";
+import AdminNoticeModal, { AdminNotice } from "../components/admin/AdminNoticeModal";
+import adminNoticeService from "../services/adminNotice.service";
 
 const excludeDefaultLayoutRoutes = ["/admin/config/[category]"];
 const availableMantineColors = [
@@ -252,6 +254,33 @@ function App({ Component, pageProps }: AppProps) {
   const language = useRef(pageProps.language);
   moment.locale(language.current);
 
+  const [pendingNotices, setPendingNotices] = useState<AdminNotice[]>([]);
+
+  useEffect(() => {
+    if (user?.isAdmin) {
+      adminNoticeService
+        .getPendingNotices()
+        .then((notices) => {
+          if (notices && Array.isArray(notices)) {
+            setPendingNotices(notices);
+          }
+        })
+        .catch(() => {});
+    }
+  }, [user?.id, user?.isAdmin]);
+
+  const handleDismissNotice = async (noticeId: string) => {
+    setPendingNotices((prev) => prev.filter((n) => n.id !== noticeId));
+    try {
+      await adminNoticeService.dismissNotice(noticeId);
+    } catch {
+      adminNoticeService
+        .getPendingNotices()
+        .then((notices) => setPendingNotices(notices || []))
+        .catch(() => {});
+    }
+  };
+
   return (
     <>
       <Head>
@@ -296,6 +325,10 @@ function App({ Component, pageProps }: AppProps) {
                     },
                   }}
                 >
+                  <AdminNoticeModal
+                    notice={pendingNotices[0] || null}
+                    onDismiss={handleDismissNotice}
+                  />
                   {excludeDefaultLayoutRoutes.includes(route) ? (
                     <Component {...pageProps} />
                   ) : (

--- a/frontend/src/services/adminNotice.service.ts
+++ b/frontend/src/services/adminNotice.service.ts
@@ -1,0 +1,15 @@
+import api from "./api.service";
+import { AdminNotice } from "../components/admin/AdminNoticeModal";
+
+const getPendingNotices = async (): Promise<AdminNotice[]> => {
+  return (await api.get("/admin-notices/pending")).data;
+};
+
+const dismissNotice = async (id: string): Promise<void> => {
+  await api.post(`/admin-notices/${id}/dismiss`);
+};
+
+export default {
+  getPendingNotices,
+  dismissNotice,
+};


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

Github Copilot was used for auto-complete. Gemini was used for ideation (working out the best implementation for this), code review, generation of the front-end modal (which was then reviewed and pruned by me) and translation.

## What's new?
- A framework has been created for showing alerts to Administrators. The primary purpose of this is the s3_presigned branch will introduce breaking changes. The framework adds:
  - A blocking (can’t click away) pop-up that will be displayed to all Administrators until *any one* of them has acknowledged and dismissed it.
  - New alerts can be added via a new json object in `backend/src/adminNotice/admin-notices.json`.
  - Notices can be conditional. e.g. the first notice that has been added is only shown if S3 has been enabled.
  - Notices are shown to all admins on all devices, however once dismissed it won’t be shown again at all.
  - Translations have been added (with AI) for every supported language, this is not my preferred way of doing things (adding to CrowdIn translations via a feature PR), however I felt its important that admins in any language can see the notice shouldn’t be ignored and they should translate it themselves.
 
## How has it been tested?
- Checked that notice doesn’t show with S3 disabled.
- Checked notice shows with S3 enabled.
- Notice only shows for Admins.
- Notice doesn’t show again after a reload.
- Notice can’t be clicked out of, can only be dismissed by checking the checkbox and clicking acknowledge button.

## Screenshots

The first notice that will be shown:


<img width="1305" height="693" alt="image" src="https://github.com/user-attachments/assets/323fd97f-261b-465a-b804-322fb9d3f583" />


