### PR TITLE
fix(dropzone): remove transparency from folder button in dark mode

### DIFF
--- a/frontend/src/components/upload/Dropzone.tsx
+++ b/frontend/src/components/upload/Dropzone.tsx
@@ -1,4 +1,12 @@
-import { Button, Center, createStyles, Group, Text, Menu } from "@mantine/core";
+import {
+  Button,
+  Center,
+  createStyles,
+  Group,
+  Text,
+  Menu,
+  useMantineColorScheme,
+} from "@mantine/core";
 import { Dropzone as MantineDropzone } from "@mantine/dropzone";
 import React, { ForwardedRef, useEffect, useRef, useState } from "react";
 import { TbCloudUpload, TbUpload, TbFolder } from "react-icons/tb";
@@ -132,6 +140,8 @@ const Dropzone = ({
   const openRef = useRef<() => void>();
   const folderInputRef = useRef<HTMLInputElement>(null);
   const [isMounted, setIsMounted] = useState(false);
+  const { colorScheme } = useMantineColorScheme();
+  const dark = colorScheme === "dark";
 
   useEffect(() => {
     setIsMounted(true);
@@ -226,7 +236,7 @@ const Dropzone = ({
         {isFolderUploadSupported && (
           <Button
             className={classes.control}
-            variant="light"
+            variant={dark ? "filled" : "light"}
             size="sm"
             radius="xl"
             disabled={isUploading}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [ ] Yes
- [x] No

## What's new?
- The Dropzone Upload/Append folder button had a transparent background in dark mode, causing poor readability. Now the button is filled and consistent with other buttons in dark mode.

## How has it been tested?
- Manually switched from light mode to dark mode under “My account”. Button is now filled and consistent with other main UI buttons in dark mode on both the upload page and the add/remove files page.

## Screenshots

Previously:

<img width="2014" height="803" alt="image" src="https://github.com/user-attachments/assets/f568e5b9-e77a-4410-8b4e-1d4619fc65b7" />


Now fixed:

<img width="2057" height="818" alt="image" src="https://github.com/user-attachments/assets/e68a4a7a-19d5-45cf-8b2c-01bf20cb89dc" />


Closes #177 
