### PR TITLE
feat: customisable password policy

### DIFF
--- a/backend/prisma/seed/config.seed.ts
+++ b/backend/prisma/seed/config.seed.ts
@@ -40,6 +40,38 @@ export const configVariables = {
       secret: false,
     },
   },
+  security: {
+    customPasswordPolicy: {
+      type: "boolean",
+      defaultValue: "false",
+      secret: false,
+    },
+    minLength: {
+      type: "number",
+      defaultValue: "8",
+      secret: false,
+    },
+    requireUppercase: {
+      type: "boolean",
+      defaultValue: "false",
+      secret: false,
+    },
+    requireLowercase: {
+      type: "boolean",
+      defaultValue: "false",
+      secret: false,
+    },
+    requireNumber: {
+      type: "boolean",
+      defaultValue: "false",
+      secret: false,
+    },
+    requireSpecialCharacter: {
+      type: "boolean",
+      defaultValue: "false",
+      secret: false,
+    },
+  },
   appearance: {
     themePrimaryColor: {
       type: "string",
@@ -570,7 +602,7 @@ async function migrateConfigVariables() {
   for (const existingConfigVariable of existingConfigVariables) {
     const configVariable =
       configVariables[existingConfigVariable.category]?.[
-      existingConfigVariable.name
+        existingConfigVariable.name
       ];
 
     // Delete the config variable if it doesn't exist in the seed

--- a/backend/src/i18n/en-US/auth.json
+++ b/backend/src/i18n/en-US/auth.json
@@ -16,5 +16,6 @@
   "ldapResetPasswordNotAllowed": "This account can't reset its password here. Please contact your administrator.",
   "userAlreadyExists": "A user with this {field} already exists",
   "accountNotActivated": "Account not activated. Please verify your email.",
-  "userAlreadyActivated": "User already activated"
+  "userAlreadyActivated": "User already activated",
+  "passwordPolicyNotMet": "Password does not meet the policy requirements."
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -35,7 +35,11 @@ export class UserSevice {
 
   async create(dto: CreateUserDTO) {
     let hash: string;
-    let randomPassword;
+    let randomPassword: string;
+
+    if (dto.password && !(await this.enforcePasswordPolicy(dto.password))) {
+      throw new BadRequestException(this.i18n.t("auth.passwordPolicyNotMet"));
+    }
 
     // The password can be undefined if the user is invited by an admin
     if (!dto.password) {
@@ -76,6 +80,13 @@ export class UserSevice {
 
   async update(id: string, user: UpdateUserDto) {
     try {
+
+      if (user.password && !(await this.enforcePasswordPolicy(user.password))) {
+        throw new BadRequestException(
+          this.i18n.t("auth.passwordPolicyNotMet"),
+        );
+      }
+
       const hash = user.password && (await argon.hash(user.password));
 
       return await this.prisma.user.update({
@@ -242,5 +253,35 @@ export class UserSevice {
         }
       }
     }
+  }
+
+  async enforcePasswordPolicy(password: string): Promise<boolean> {
+    if (!this.configService.get("security.customPasswordPolicy")) {
+      return true;
+    }
+
+    const minLength = this.configService.get("security.minLength");
+    const requireUppercase = this.configService.get(
+      "security.requireUppercase",
+    );
+    const requireLowercase = this.configService.get(
+      "security.requireLowercase",
+    );
+    const requireNumber = this.configService.get("security.requireNumber");
+    const requireSpecialCharacter = this.configService.get(
+      "security.requireSpecialCharacter",
+    );
+
+    if (
+      password.length < minLength ||
+      (!password.match(/[A-Z]/) && requireUppercase) ||
+      (!password.match(/[a-z]/) && requireLowercase) ||
+      (!password.match(/[0-9]/) && requireNumber) ||
+      (!password.match(/[^A-Za-z0-9]/) && requireSpecialCharacter)
+    ) {
+      return false;
+    }
+
+    return true;
   }
 }

--- a/frontend/src/components/admin/configuration/ConfigurationNavBar.tsx
+++ b/frontend/src/components/admin/configuration/ConfigurationNavBar.tsx
@@ -15,6 +15,7 @@ import {
   TbAt,
   TbBinaryTree,
   TbBucket,
+  TbLock,
   TbMail,
   TbPalette,
   TbScale,
@@ -28,6 +29,7 @@ import { FormattedMessage } from "react-intl";
 export const categories = [
   { name: "General", icon: <TbSettings /> },
   { name: "Appearance", icon: <TbPalette /> },
+  { name: "Security", icon: <TbLock /> },
   { name: "Email", icon: <TbMail /> },
   { name: "Share", icon: <TbShare /> },
   { name: "SMTP", icon: <TbAt /> },

--- a/frontend/src/components/admin/users/ManageUserTable.tsx
+++ b/frontend/src/components/admin/users/ManageUserTable.tsx
@@ -7,17 +7,20 @@ import { FormattedMessage } from "react-intl";
 import useTranslate from "../../../hooks/useTranslate.hook";
 import { HoverTip } from "../../core/HoverTip";
 import { byteToHumanSizeString } from "../../../utils/fileSize.util";
+import { CustomPasswordPolicy } from "../../../types/config.type";
 
 const ManageUserTable = ({
   users,
   getUsers,
   deleteUser,
   isLoading,
+  customPasswordPolicy,
 }: {
   users: User[];
   getUsers: () => void;
   deleteUser: (user: User) => void;
   isLoading: boolean;
+  customPasswordPolicy: CustomPasswordPolicy;
 }) => {
   const modals = useModals();
   const t = useTranslate();
@@ -90,7 +93,7 @@ const ManageUserTable = ({
                             color="blue"
                             size={25}
                             onClick={() =>
-                              showUpdateUserModal(modals, user, getUsers)
+                              showUpdateUserModal(modals, user, getUsers, customPasswordPolicy)
                             }
                           >
                             <TbEdit />

--- a/frontend/src/components/admin/users/showCreateUserModal.tsx
+++ b/frontend/src/components/admin/users/showCreateUserModal.tsx
@@ -14,16 +14,18 @@ import useTranslate from "../../../hooks/useTranslate.hook";
 import userService from "../../../services/user.service";
 import toast from "../../../utils/toast.util";
 import FileSizeInput from "../../core/FileSizeInput";
+import { CustomPasswordPolicy } from "../../../types/config.type";
 
 const showCreateUserModal = (
   modals: ModalsContextProps,
   smtpEnabled: boolean,
   getUsers: () => void,
+  customPasswordPolicy: CustomPasswordPolicy,
 ) => {
   return modals.openModal({
     title: "Create user",
     children: (
-      <Body modals={modals} smtpEnabled={smtpEnabled} getUsers={getUsers} />
+      <Body modals={modals} smtpEnabled={smtpEnabled} getUsers={getUsers} customPasswordPolicy={customPasswordPolicy} />
     ),
   });
 };
@@ -32,12 +34,15 @@ const Body = ({
   modals,
   smtpEnabled,
   getUsers,
+  customPasswordPolicy,
 }: {
   modals: ModalsContextProps;
   smtpEnabled: boolean;
   getUsers: () => void;
+  customPasswordPolicy: CustomPasswordPolicy;
 }) => {
   const t = useTranslate();
+
   const form = useForm({
     initialValues: {
       username: "",
@@ -58,7 +63,12 @@ const Body = ({
           .min(3, t("common.error.too-short", { length: 3 })),
         password: yup
           .string()
-          .min(8, t("common.error.too-short", { length: 8 }))
+          .min(customPasswordPolicy.minLength, t("common.error.too-short", { length: customPasswordPolicy.minLength }))
+          .matches(customPasswordPolicy.requireLowercase ? /[a-z]/ : /.*/, t("common.error.password.lowercase"))
+          .matches(customPasswordPolicy.requireUppercase ? /[A-Z]/ : /.*/, t("common.error.password.uppercase"))
+          .matches(customPasswordPolicy.requireNumber ? /[0-9]/ : /.*/, t("common.error.password.number"))
+          .matches(customPasswordPolicy.requireSpecialCharacter ? /[^a-zA-Z0-9]/ : /.*/, t("common.error.password.special"))
+          .required(t("common.error.field-required"))
           .optional(),
         storageQuotaLimit: yup
           .number()

--- a/frontend/src/components/admin/users/showUpdateUserModal.tsx
+++ b/frontend/src/components/admin/users/showUpdateUserModal.tsx
@@ -18,16 +18,25 @@ import userService from "../../../services/user.service";
 import User from "../../../types/user.type";
 import toast from "../../../utils/toast.util";
 import FileSizeInput from "../../core/FileSizeInput";
+import { CustomPasswordPolicy } from "../../../types/config.type";
 
 const showUpdateUserModal = (
   modals: ModalsContextProps,
   user: User,
   getUsers: () => void,
+  customPasswordPolicy: CustomPasswordPolicy,
 ) => {
   const t = translateOutsideContext();
   return modals.openModal({
     title: t("admin.users.edit.update.title", { username: user.username }),
-    children: <Body user={user} modals={modals} getUsers={getUsers} />,
+    children: (
+      <Body
+        user={user}
+        modals={modals}
+        getUsers={getUsers}
+        customPasswordPolicy={customPasswordPolicy}
+      />
+    ),
   });
 };
 
@@ -35,10 +44,12 @@ const Body = ({
   user,
   modals,
   getUsers,
+  customPasswordPolicy,
 }: {
   modals: ModalsContextProps;
   user: User;
   getUsers: () => void;
+  customPasswordPolicy: CustomPasswordPolicy;
 }) => {
   const t = useTranslate();
 
@@ -85,7 +96,31 @@ const Body = ({
       yup.object().shape({
         password: yup
           .string()
-          .min(8, t("common.error.too-short", { length: 8 })),
+          .min(
+            customPasswordPolicy.minLength,
+            t("common.error.too-short", {
+              length: customPasswordPolicy.minLength,
+            }),
+          )
+          .matches(
+            customPasswordPolicy.requireLowercase ? /[a-z]/ : /.*/,
+            t("common.error.password.lowercase"),
+          )
+          .matches(
+            customPasswordPolicy.requireUppercase ? /[A-Z]/ : /.*/,
+            t("common.error.password.uppercase"),
+          )
+          .matches(
+            customPasswordPolicy.requireNumber ? /[0-9]/ : /.*/,
+            t("common.error.password.number"),
+          )
+          .matches(
+            customPasswordPolicy.requireSpecialCharacter
+              ? /[^a-zA-Z0-9]/
+              : /.*/,
+            t("common.error.password.special"),
+          )
+          .required(t("common.error.field-required")),
       }),
     ),
   });

--- a/frontend/src/components/auth/SignUpForm.tsx
+++ b/frontend/src/components/auth/SignUpForm.tsx
@@ -26,15 +26,15 @@ const SignUpForm = () => {
   const { refreshUser } = useUser();
 
   let minLength = 8;
-  let requireLower = false;
-  let requireUpper = false;
+  let requireLowercase = false;
+  let requireUppercase = false;
   let requireNumber = false;
   let requireSpecialCharacter = false;
 
   if (config.get("security.customPasswordPolicy")) {
     minLength = config.get("security.minLength");
-    requireLower = config.get("security.requireLowercase");
-    requireUpper = config.get("security.requireUppercase");
+    requireLowercase = config.get("security.requireLowercase");
+    requireUppercase = config.get("security.requireUppercase");
     requireNumber = config.get("security.requireNumber");
     requireSpecialCharacter = config.get("security.requireSpecialCharacter");
   } 
@@ -48,8 +48,8 @@ const SignUpForm = () => {
     password: yup
       .string()
       .min(minLength, t("common.error.too-short", { length: minLength }))
-      .matches(requireLower ? /[a-z]/ : /.*/, t("common.error.password.lowercase"))
-      .matches(requireUpper ? /[A-Z]/ : /.*/, t("common.error.password.uppercase"))
+      .matches(requireLowercase ? /[a-z]/ : /.*/, t("common.error.password.lowercase"))
+      .matches(requireUppercase ? /[A-Z]/ : /.*/, t("common.error.password.uppercase"))
       .matches(requireNumber ? /[0-9]/ : /.*/, t("common.error.password.number"))
       .matches(requireSpecialCharacter ? /[^a-zA-Z0-9]/ : /.*/, t("common.error.password.special"))
       .required(t("common.error.field-required")),

--- a/frontend/src/components/auth/SignUpForm.tsx
+++ b/frontend/src/components/auth/SignUpForm.tsx
@@ -25,6 +25,20 @@ const SignUpForm = () => {
   const t = useTranslate();
   const { refreshUser } = useUser();
 
+  let minLength = 8;
+  let requireLower = false;
+  let requireUpper = false;
+  let requireNumber = false;
+  let requireSpecialCharacter = false;
+
+  if (config.get("security.customPasswordPolicy")) {
+    minLength = config.get("security.minLength");
+    requireLower = config.get("security.requireLowercase");
+    requireUpper = config.get("security.requireUppercase");
+    requireNumber = config.get("security.requireNumber");
+    requireSpecialCharacter = config.get("security.requireSpecialCharacter");
+  } 
+
   const validationSchema = yup.object().shape({
     email: yup.string().email(t("common.error.invalid-email")).required(),
     username: yup
@@ -33,7 +47,11 @@ const SignUpForm = () => {
       .required(t("common.error.field-required")),
     password: yup
       .string()
-      .min(8, t("common.error.too-short", { length: 8 }))
+      .min(minLength, t("common.error.too-short", { length: minLength }))
+      .matches(requireLower ? /[a-z]/ : /.*/, t("common.error.password.lowercase"))
+      .matches(requireUpper ? /[A-Z]/ : /.*/, t("common.error.password.uppercase"))
+      .matches(requireNumber ? /[0-9]/ : /.*/, t("common.error.password.number"))
+      .matches(requireSpecialCharacter ? /[^a-zA-Z0-9]/ : /.*/, t("common.error.password.special"))
       .required(t("common.error.field-required")),
   });
 

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -493,6 +493,7 @@ export default {
   "admin.config.title": "Configuration",
   "admin.config.category.general": "General",
   "admin.config.category.appearance": "Appearance",
+  "admin.config.category.security": "Security & Access",
   "admin.config.category.share": "Share",
   "admin.config.category.cache": "Cache",
   "admin.config.category.email": "Email",
@@ -547,6 +548,18 @@ export default {
   "admin.config.general.logo-dark.description":
     "Upload a separate logo for dark mode. The image must be a PNG and should have the format 1:1.",
   "admin.config.general.logo.placeholder": "Pick image",
+  "admin.config.security.custom-password-policy": "Custom password policy",
+  "admin.config.security.custom-password-policy.description": "Whether to enable customisation of the password policy. If disabled, the default password policy of an 8 character minimum is used.",
+  "admin.config.security.min-length": "Minimum length",
+  "admin.config.security.min-length.description": "Minimum number of characters required for a password.",
+  "admin.config.security.require-uppercase": "Require uppercase",
+  "admin.config.security.require-uppercase.description": "Whether to require at least one uppercase letter in the password.",
+  "admin.config.security.require-lowercase": "Require lowercase",
+  "admin.config.security.require-lowercase.description": "Whether to require at least one lowercase letter in the password.",
+  "admin.config.security.require-number": "Require number",
+  "admin.config.security.require-number.description": "Whether to require at least one number in the password.",
+  "admin.config.security.require-special-character": "Require special character",
+  "admin.config.security.require-special-character.description": "Whether to require at least one special character in the password.",
   "admin.config.cache.ttl": "TTL",
   "admin.config.cache.ttl.description":
     "Time in second to keep information inside the cache.",
@@ -604,7 +617,7 @@ export default {
   "admin.config.email.share-recipients-reply-to-creator":
     "Set Reply-To to creator's email",
   "admin.config.email.share-recipients-reply-to-creator.description":
-  "Whether to set the Reply-To header to the email address of the user who created the share.",
+    "Whether to set the Reply-To header to the email address of the user who created the share.",
   "admin.config.email.enable-share-download-notifications":
     "Enable download notifications",
   "admin.config.email.enable-share-download-notifications.description":

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -944,6 +944,11 @@ export default {
   "common.error.invalid-number": "Must be a number",
   "common.error.field-required": "This field is required",
 
+  "common.error.password.lowercase": "Password must contain at least one lowercase letter",
+  "common.error.password.uppercase": "Password must contain at least one uppercase letter",
+  "common.error.password.number": "Password must contain at least one number",
+  "common.error.password.special": "Password must contain at least one special character",
+
   "admin.notice.modal.headerTag": "ADMINISTRATIVE ACTION REQUIRED",
   "admin.notice.modal.defaultCheckboxLabel": "I confirm that I have read this notice and understand the breaking changes.",
   "admin.notice.modal.button.acknowledge": "Acknowledge & Dismiss",

--- a/frontend/src/pages/admin/config/[category].tsx
+++ b/frontend/src/pages/admin/config/[category].tsx
@@ -35,6 +35,7 @@ import toast from "../../../utils/toast.util";
 const categories = [
   "General",
   "Appearance",
+  "Security",
   "Email",
   "Share",
   "SMTP",

--- a/frontend/src/pages/admin/config/[category].tsx
+++ b/frontend/src/pages/admin/config/[category].tsx
@@ -218,6 +218,7 @@ export default function AppShellDemo() {
                 const shouldShowPrimaryColorOverride =
                   getEffectiveConfigValue("appearance.themePrimaryColor") ===
                   "custom";
+                const shouldShowCustomPasswordPolicies = getEffectiveConfigValue("security.customPasswordPolicy") === "true";
                 const visibleConfigVariables = configVariables.filter(
                   (configVariable) =>
                     configVariable.key !== "appearance.customCss",
@@ -263,9 +264,20 @@ export default function AppShellDemo() {
                       )}
                       {visibleConfigVariables.map((configVariable) => {
                         if (
-                          configVariable.key ===
+                          (configVariable.key ===
                             "appearance.themePrimaryColorOverride" &&
-                          !shouldShowPrimaryColorOverride
+                            !shouldShowPrimaryColorOverride) ||
+                          (configVariable.key === "security.minLength" &&
+                            !shouldShowCustomPasswordPolicies) ||
+                          (configVariable.key === "security.requireLowercase" &&
+                            !shouldShowCustomPasswordPolicies) ||
+                          (configVariable.key === "security.requireUppercase" &&
+                            !shouldShowCustomPasswordPolicies) ||
+                          (configVariable.key === "security.requireNumber" &&
+                            !shouldShowCustomPasswordPolicies) ||
+                          (configVariable.key ===
+                            "security.requireSpecialCharacter" &&
+                            !shouldShowCustomPasswordPolicies)
                         ) {
                           return null;
                         }
@@ -373,6 +385,9 @@ export default function AppShellDemo() {
                             </Box>
                           </Group>
                         )}
+                      {/* {categoryId === "security" && shouldShowCustomPasswordPolicies && ( */}
+                      {/**/}
+                      {/* )} */}
                     </Stack>
                   </>
                 );

--- a/frontend/src/pages/admin/users.tsx
+++ b/frontend/src/pages/admin/users.tsx
@@ -10,10 +10,19 @@ import useConfig from "../../hooks/config.hook";
 import useTranslate from "../../hooks/useTranslate.hook";
 import userService from "../../services/user.service";
 import User from "../../types/user.type";
+import { CustomPasswordPolicy } from "../../types/config.type";
 import toast from "../../utils/toast.util";
 
 const Users = () => {
   const [users, setUsers] = useState<User[]>([]);
+  const [customPasswordPolicy, setCustomPasswordPolicy] =
+    useState<CustomPasswordPolicy>({
+      minLength: 8,
+      requireUppercase: false,
+      requireLowercase: false,
+      requireNumber: false,
+      requireSpecialCharacter: false,
+    });
   const [isLoading, setIsLoading] = useState(true);
 
   const config = useConfig();
@@ -54,6 +63,20 @@ const Users = () => {
 
   useEffect(() => {
     getUsers();
+
+    let customPasswordPolicy: CustomPasswordPolicy;
+    if (config.get("security.customPasswordPolicy")) {
+      customPasswordPolicy = {
+        minLength: config.get("security.minLength"),
+        requireUppercase: config.get("security.requireUppercase"),
+        requireLowercase: config.get("security.requireLowercase"),
+        requireNumber: config.get("security.requireNumber"),
+        requireSpecialCharacter: config.get(
+          "security.requireSpecialCharacter",
+        ),
+      };
+      setCustomPasswordPolicy(customPasswordPolicy);
+    }
   }, []);
 
   return (
@@ -65,7 +88,7 @@ const Users = () => {
         </Title>
         <Button
           onClick={() =>
-            showCreateUserModal(modals, config.get("smtp.enabled"), getUsers)
+            showCreateUserModal(modals, config.get("smtp.enabled"), getUsers, customPasswordPolicy)
           }
           leftIcon={<TbPlus size={20} />}
         >
@@ -78,6 +101,7 @@ const Users = () => {
         getUsers={getUsers}
         deleteUser={deleteUser}
         isLoading={isLoading}
+        customPasswordPolicy={customPasswordPolicy}
       />
       <Space h="xl" />
     </>

--- a/frontend/src/services/config.service.ts
+++ b/frontend/src/services/config.service.ts
@@ -6,6 +6,7 @@ import { stringToTimespan } from "../utils/date.util";
 const categories = [
   "general",
   "appearance",
+  "security",
   "email",
   "share",
   "smtp",

--- a/frontend/src/types/config.type.ts
+++ b/frontend/src/types/config.type.ts
@@ -41,4 +41,12 @@ export type ConfigHook = {
   refresh: () => void;
 };
 
+export type CustomPasswordPolicy= {
+  minLength: number;
+  requireLowercase: boolean;
+  requireUppercase: boolean;
+  requireNumber: boolean;
+  requireSpecialCharacter: boolean;
+};
+
 export default Config;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

Github Copilot was used for autocomplete.

## What's new?
- New “Security & Access” page, in the Administration Configuration, which will be used to consolidate/add new security settings to, as per #138.
- New Custom password policy config with the below options. If left disabled, the default policy of only requiring a minimum length of 8 characters is still enforced.
  - Minimum password length (can’t be lowered below 8)
  - Require uppercase letter (boolean)
  - Require lowercase letter (boolean)
  - Require numbers (boolean)
  - Require special characters (boolean)

## How has it been tested?
- With custom password policy disabled:
  - Signs up can enter any password as long as its >= 8 chars, error message still appears if below.
  - Admin can create an account with any >= 8 chars password, error message still appears if below.
  - Admin can modify existing user to have any password >= 8 chars.
- With custom password policy enabled:
  - With only minimum length specified, set to 12:
    - Signs up can enter any password as long its >= 12 chars. Other character rules aren’t enforced, as exepected.
    - Admins create and modify password capability follows.
  - With all policies enabled:
    - Sign ups must be >= 12 chars, contains lower, upper, number and special chars.
    - Admins create and modify password follows.        

## Screenshots

New “Security & Access” page with Custom password policy disabled:

<img width="2732" height="705" alt="image" src="https://github.com/user-attachments/assets/4752d044-8609-4f08-8ab1-1fb071fb1b54" />


With Custom password policy enabled:

<img width="2732" height="1445" alt="image" src="https://github.com/user-attachments/assets/47296dc2-eee5-4121-ace4-f86bf53bf8b8" />


Closes #124 