### PR TITLE
fix(filePreview): better handle original file link

### DIFF
--- a/backend/src/file/file.controller.ts
+++ b/backend/src/file/file.controller.ts
@@ -170,16 +170,28 @@ export class FileController {
 
     const file = await this.fileService.get(shareId, fileId);
 
-    const headers = {
-      "Content-Type":
-        mime?.lookup?.(file.metaData.name) || "application/octet-stream",
+    const mimeType =
+      mime?.lookup?.(file.metaData.name) || "application/octet-stream";
+
+    const isPassiveMedia =
+      mimeType.startsWith("video/") ||
+      mimeType.startsWith("audio/") ||
+      (mimeType.startsWith("image/") && mimeType !== "image/svg+xml") ||
+      mimeType === "text/plain";
+
+    const headers: Record<string, any> = {
+      "Content-Type": mimeType,
       "Content-Length": file.metaData.size,
-      "Content-Security-Policy": "sandbox",
+      "X-Content-Type-Options": "nosniff",
       "Content-Disposition": contentDisposition(
         file.metaData.name,
         isDownload ? undefined : { type: "inline" },
       ),
     };
+
+    if (!isPassiveMedia) {
+      headers["Content-Security-Policy"] = "sandbox";
+    }
 
     res.set(headers);
 

--- a/frontend/src/components/share/FilePreview.tsx
+++ b/frontend/src/components/share/FilePreview.tsx
@@ -6,9 +6,7 @@ import {
   Title,
   useMantineTheme,
 } from "@mantine/core";
-import { modals } from "@mantine/modals";
 import Markdown, { MarkdownToJSX } from "markdown-to-jsx";
-import Link from "next/link";
 import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import api from "../../services/api.service";
@@ -46,9 +44,9 @@ const FilePreview = ({
       </FilePreviewContext.Provider>
       <Button
         variant="subtle"
-        component={Link}
-        onClick={() => modals.closeAll()}
+        component="a"
         target="_blank"
+        rel="noreferrer"
         href={`/api/shares/${shareId}/files/${fileId}?download=false`}
       >
         View original file

--- a/frontend/src/components/share/FilePreview.tsx
+++ b/frontend/src/components/share/FilePreview.tsx
@@ -49,8 +49,7 @@ const FilePreview = ({
         rel="noreferrer"
         href={`/api/shares/${shareId}/files/${fileId}?download=false`}
       >
-        View original file
-        {/* Add translation? */}
+        <FormattedMessage id="share.modal.file-preview.original_file" />
       </Button>
     </Stack>
   );

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -464,6 +464,7 @@ export default {
   "share.table.name": "Name",
   "share.table.size": "Size",
 
+  "share.modal.file-preview.original_file": "View original file",
   "share.modal.file-preview.error.not-supported.title": "Preview not supported",
   "share.modal.file-preview.error.not-supported.description":
     "Previews are not supported for this type of files. Please download the file to view it.",


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [ ] Yes
- [x] No

## What's new?
- The original file link for video previews attempted to use the NextJS Link component, which tried to do NextJS routing on what is meant to be an external link, this has been switched to a basic HTML <a> component. This should prevent funkyness on certain setups.
- “Original file link” text for video previews was a hardcoded English string, it has been switched to a translatable i18n string. 

## How has it been tested?
- Tested button behaves as expected (opens video in new tab) on Chromium and Firefox on desktop linux, as well as Firefox on iOS.

Closes #190 
