### PR TITLE
fix(s3): pregenerate file id, resolves multi-chunk uploads

### DIFF
--- a/frontend/src/services/share.service.ts
+++ b/frontend/src/services/share.service.ts
@@ -11,6 +11,7 @@ import {
   ShareMetaData,
   UpdateShare,
 } from "../types/share.type";
+import { generateUUID } from "../utils/crypto.util";
 import api from "./api.service";
 
 const isValidId = (id: string) => {
@@ -146,14 +147,15 @@ const uploadFileDirectS3 = async (
   totalChunks: number,
   onUploadProgress?: (progressEvent: any) => void,
 ): Promise<FileUploadResponse> => {
-  const sessionKey = `${shareId}:${file.id || file.name}`;
+  const fileId = file.id || generateUUID();
+  const sessionKey = `${shareId}:${file.name}`;
 
   try {
     if (chunkIndex === 0 && !s3UploadSessions[sessionKey]) {
       const initResponse = await api.post(
         `shares/${shareId}/files/upload-init`,
         {
-          id: file.id,
+          id: fileId,
           name: file.name,
           totalChunks,
         },
@@ -163,7 +165,7 @@ const uploadFileDirectS3 = async (
         uploadId: initResponse.data.uploadId,
         urls: initResponse.data.urls,
         parts: [],
-        fileId: file.id || "",
+        fileId: fileId,
       };
     }
 
@@ -198,7 +200,7 @@ const uploadFileDirectS3 = async (
       const completeResponse = await api.post(
         `shares/${shareId}/files/upload-complete`,
         {
-          id: session.fileId || undefined,
+          id: session.fileId || fileId,
           name: file.name,
           uploadId: session.uploadId,
           parts: session.parts,
@@ -209,7 +211,8 @@ const uploadFileDirectS3 = async (
     }
 
     return {
-      id: session.fileId || "s3-upload-in-progress",
+      id: session.fileId || fileId,
+      name: file.name,
     } as FileUploadResponse;
   } catch (error) {
     const session = s3UploadSessions[sessionKey];
@@ -266,13 +269,15 @@ const uploadFile = async (
       translateOutsideContext()("upload.modal.link.error.invalid"),
     );
 
-  const sessionKey = `${shareId}:${file.id || file.name}`;
+  const fileId = file.id || generateUUID();
+  const fileWithId = { ...file, id: fileId };
+  const sessionKey = `${shareId}:${file.name}`;
 
   if (s3UploadSessions[sessionKey]) {
     return uploadFileDirectS3(
       shareId,
       chunk,
-      file,
+      fileWithId,
       chunkIndex,
       totalChunks,
       onUploadProgress,
@@ -283,7 +288,7 @@ const uploadFile = async (
     return uploadFileProxied(
       shareId,
       chunk,
-      file,
+      fileWithId,
       chunkIndex,
       totalChunks,
       onUploadProgress,
@@ -295,8 +300,8 @@ const uploadFile = async (
       const initResponse = await api.post(
         `shares/${shareId}/files/upload-init`,
         {
-          id: file.id,
-          name: file.name,
+          id: fileWithId.id,
+          name: fileWithId.name,
           totalChunks,
         },
       );
@@ -307,12 +312,12 @@ const uploadFile = async (
           uploadId: initResponse.data.uploadId,
           urls: initResponse.data.urls,
           parts: [],
-          fileId: file.id || "",
+          fileId: fileWithId.id,
         };
         return uploadFileDirectS3(
           shareId,
           chunk,
-          file,
+          fileWithId,
           chunkIndex,
           totalChunks,
           onUploadProgress,
@@ -332,7 +337,7 @@ const uploadFile = async (
   return uploadFileProxied(
     shareId,
     chunk,
-    file,
+    fileWithId,
     chunkIndex,
     totalChunks,
     onUploadProgress,

--- a/frontend/src/utils/crypto.util.ts
+++ b/frontend/src/utils/crypto.util.ts
@@ -1,0 +1,26 @@
+export const generateUUID = (): string => {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.getRandomValues === "function"
+  ) {
+    return "10000000-1000-4000-8000-100000000000".replace(/[018]/g, (c) =>
+      (
+        +c ^
+        (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (+c / 4)))
+      ).toString(16),
+    );
+  }
+
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+};


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

Github Copilot was used for autocomplete. Gemini was used for code review.

## What's new?
- Multichunk uploads were failing with the new S3 update. The cause of this was the file.id not being consistent throughout the upload, a placeholder id was used which caused a id error for multichunk uploads.
  - This PR fixes that by pre-generating the file.id on the frontend through the use of a new crypto utility (which attempts to utilise the browser crypto function, with fallbacks) 

## How has it been tested?
- With S3 enabled I uploaded single chunk (where a chunk was the default size of 10MB) and multichunk files, previously only single chunk worked, now all file uploads work as expected.
