### PR TITLE
fix(upload): retry stalled transfers

### DIFF
--- a/frontend/src/services/share.service.ts
+++ b/frontend/src/services/share.service.ts
@@ -1,6 +1,6 @@
 import { deleteCookie, setCookie } from "cookies-next";
 import mime from "mime-types";
-import axios, { type AxiosProgressEvent } from "axios";
+import axios from "axios";
 import { translateOutsideContext } from "../hooks/useTranslate.hook";
 import { FileUploadResponse } from "../types/File.type";
 import {
@@ -12,7 +12,10 @@ import {
   UpdateShare,
 } from "../types/share.type";
 import { generateUUID } from "../utils/crypto.util";
-import { withUploadInactivityTimeout } from "../utils/upload.util";
+import {
+  type UploadProgressHandler,
+  withUploadInactivityTimeout,
+} from "../utils/upload.util";
 import api from "./api.service";
 
 const isValidId = (id: string) => {
@@ -146,7 +149,7 @@ const uploadFileDirectS3 = async (
   file: { id?: string; name: string },
   chunkIndex: number,
   totalChunks: number,
-  onUploadProgress?: (progressEvent: AxiosProgressEvent) => void,
+  onUploadProgress?: UploadProgressHandler,
 ): Promise<FileUploadResponse> => {
   const fileId = file.id || generateUUID();
   const sessionKey = `${shareId}:${file.name}`;
@@ -243,25 +246,24 @@ const uploadFileProxied = async (
   file: { id?: string; name: string },
   chunkIndex: number,
   totalChunks: number,
-  onUploadProgress?: (progressEvent: AxiosProgressEvent) => void,
+  onUploadProgress?: UploadProgressHandler,
 ): Promise<FileUploadResponse> => {
-  return withUploadInactivityTimeout(
-    async (signal, handleUploadProgress) =>
-      (
-        await api.post(`shares/${shareId}/files`, chunk, {
-          signal,
-          headers: { "Content-Type": "application/octet-stream" },
-          params: {
-            id: file.id,
-            name: file.name,
-            chunkIndex,
-            totalChunks,
-          },
-          onUploadProgress: handleUploadProgress,
-        })
-      ).data,
+  const response = await withUploadInactivityTimeout(
+    (signal, handleUploadProgress) =>
+      api.post(`shares/${shareId}/files`, chunk, {
+        signal,
+        headers: { "Content-Type": "application/octet-stream" },
+        params: {
+          id: file.id,
+          name: file.name,
+          chunkIndex,
+          totalChunks,
+        },
+        onUploadProgress: handleUploadProgress,
+      }),
     onUploadProgress,
   );
+  return response.data;
 };
 
 const uploadFile = async (
@@ -273,7 +275,7 @@ const uploadFile = async (
   },
   chunkIndex: number,
   totalChunks: number,
-  onUploadProgress?: (progressEvent: AxiosProgressEvent) => void,
+  onUploadProgress?: UploadProgressHandler,
 ): Promise<FileUploadResponse> => {
   if (!isValidId(shareId))
     throw new Error(

--- a/frontend/src/services/share.service.ts
+++ b/frontend/src/services/share.service.ts
@@ -1,6 +1,6 @@
 import { deleteCookie, setCookie } from "cookies-next";
 import mime from "mime-types";
-import axios from "axios";
+import axios, { type AxiosProgressEvent } from "axios";
 import { translateOutsideContext } from "../hooks/useTranslate.hook";
 import { FileUploadResponse } from "../types/File.type";
 import {
@@ -12,6 +12,7 @@ import {
   UpdateShare,
 } from "../types/share.type";
 import { generateUUID } from "../utils/crypto.util";
+import { withUploadInactivityTimeout } from "../utils/upload.util";
 import api from "./api.service";
 
 const isValidId = (id: string) => {
@@ -145,7 +146,7 @@ const uploadFileDirectS3 = async (
   file: { id?: string; name: string },
   chunkIndex: number,
   totalChunks: number,
-  onUploadProgress?: (progressEvent: any) => void,
+  onUploadProgress?: (progressEvent: AxiosProgressEvent) => void,
 ): Promise<FileUploadResponse> => {
   const fileId = file.id || generateUUID();
   const sessionKey = `${shareId}:${file.name}`;
@@ -179,10 +180,15 @@ const uploadFileDirectS3 = async (
     }
 
     const url = session.urls[chunkIndex];
-    const response = await axios.put(url, chunk, {
-      headers: { "Content-Type": "application/octet-stream" },
+    const response = await withUploadInactivityTimeout(
+      (signal, handleUploadProgress) =>
+        axios.put(url, chunk, {
+          signal,
+          headers: { "Content-Type": "application/octet-stream" },
+          onUploadProgress: handleUploadProgress,
+        }),
       onUploadProgress,
-    });
+    );
 
     const etag = response.headers["etag"];
     if (!etag) {
@@ -237,20 +243,25 @@ const uploadFileProxied = async (
   file: { id?: string; name: string },
   chunkIndex: number,
   totalChunks: number,
-  onUploadProgress?: (progressEvent: any) => void,
+  onUploadProgress?: (progressEvent: AxiosProgressEvent) => void,
 ): Promise<FileUploadResponse> => {
-  return (
-    await api.post(`shares/${shareId}/files`, chunk, {
-      headers: { "Content-Type": "application/octet-stream" },
-      params: {
-        id: file.id,
-        name: file.name,
-        chunkIndex,
-        totalChunks,
-      },
-      onUploadProgress,
-    })
-  ).data;
+  return withUploadInactivityTimeout(
+    async (signal, handleUploadProgress) =>
+      (
+        await api.post(`shares/${shareId}/files`, chunk, {
+          signal,
+          headers: { "Content-Type": "application/octet-stream" },
+          params: {
+            id: file.id,
+            name: file.name,
+            chunkIndex,
+            totalChunks,
+          },
+          onUploadProgress: handleUploadProgress,
+        })
+      ).data,
+    onUploadProgress,
+  );
 };
 
 const uploadFile = async (
@@ -262,7 +273,7 @@ const uploadFile = async (
   },
   chunkIndex: number,
   totalChunks: number,
-  onUploadProgress?: (progressEvent: any) => void,
+  onUploadProgress?: (progressEvent: AxiosProgressEvent) => void,
 ): Promise<FileUploadResponse> => {
   if (!isValidId(shareId))
     throw new Error(

--- a/frontend/src/utils/upload.util.ts
+++ b/frontend/src/utils/upload.util.ts
@@ -2,26 +2,22 @@ import type { AxiosProgressEvent } from "axios";
 
 const UPLOAD_INACTIVITY_TIMEOUT_MS = 60_000;
 
+export type UploadProgressHandler = (progressEvent: AxiosProgressEvent) => void;
+
 type UploadRequest<T> = (
   signal: AbortSignal,
-  onUploadProgress: (progressEvent: AxiosProgressEvent) => void,
+  onUploadProgress: UploadProgressHandler,
 ) => Promise<T>;
 
 export const withUploadInactivityTimeout = async <T>(
   request: UploadRequest<T>,
-  onUploadProgress?: (progressEvent: AxiosProgressEvent) => void,
+  onUploadProgress?: UploadProgressHandler,
 ): Promise<T> => {
   const controller = new AbortController();
   let inactivityTimeout: ReturnType<typeof setTimeout> | undefined;
 
-  const clearInactivityTimeout = () => {
-    if (inactivityTimeout === undefined) return;
-    clearTimeout(inactivityTimeout);
-    inactivityTimeout = undefined;
-  };
-
   const resetInactivityTimeout = () => {
-    clearInactivityTimeout();
+    clearTimeout(inactivityTimeout);
     inactivityTimeout = setTimeout(
       () => controller.abort(),
       UPLOAD_INACTIVITY_TIMEOUT_MS,
@@ -36,6 +32,6 @@ export const withUploadInactivityTimeout = async <T>(
       onUploadProgress?.(progressEvent);
     });
   } finally {
-    clearInactivityTimeout();
+    clearTimeout(inactivityTimeout);
   }
 };

--- a/frontend/src/utils/upload.util.ts
+++ b/frontend/src/utils/upload.util.ts
@@ -1,0 +1,41 @@
+import type { AxiosProgressEvent } from "axios";
+
+const UPLOAD_INACTIVITY_TIMEOUT_MS = 60_000;
+
+type UploadRequest<T> = (
+  signal: AbortSignal,
+  onUploadProgress: (progressEvent: AxiosProgressEvent) => void,
+) => Promise<T>;
+
+export const withUploadInactivityTimeout = async <T>(
+  request: UploadRequest<T>,
+  onUploadProgress?: (progressEvent: AxiosProgressEvent) => void,
+): Promise<T> => {
+  const controller = new AbortController();
+  let inactivityTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  const clearInactivityTimeout = () => {
+    if (inactivityTimeout === undefined) return;
+    clearTimeout(inactivityTimeout);
+    inactivityTimeout = undefined;
+  };
+
+  const resetInactivityTimeout = () => {
+    clearInactivityTimeout();
+    inactivityTimeout = setTimeout(
+      () => controller.abort(),
+      UPLOAD_INACTIVITY_TIMEOUT_MS,
+    );
+  };
+
+  resetInactivityTimeout();
+
+  try {
+    return await request(controller.signal, (progressEvent) => {
+      resetInactivityTimeout();
+      onUploadProgress?.(progressEvent);
+    });
+  } finally {
+    clearInactivityTimeout();
+  }
+};


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage

- [x] Yes
- [ ] No

I used Codex to help investigate the logs, reproduce the stalled request and prepare this patch. I manually de-slopped and optimized it.

## What's new?

An upload that stops making progress is now aborted after 60 seconds. That lets the existing retry loop take over instead of leaving a file at 99.9% indefinitely.

The timer resets whenever upload progress is reported and is cleared when the request finishes. This covers both proxied uploads and direct S3 uploads.

Closes #202.

## How has it been tested?

- Reproduced a request that stopped 1,480 bytes short and remained open
- Confirmed a full retry completed successfully
- Checked timeout, progress reset and timer cleanup locally
- Ran frontend lint and TypeScript checks
- Ran a production frontend build

## Screenshots

N/A
