### PR TITLE
feat: per user feature permissions 

### DIFF
--- a/backend/prisma/migrations/20260831172115_add_user_permissions_and_limits/migration.sql
+++ b/backend/prisma/migrations/20260831172115_add_user_permissions_and_limits/migration.sql
@@ -1,0 +1,34 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "username" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "password" TEXT,
+    "isAdmin" BOOLEAN NOT NULL DEFAULT false,
+    "ldapDN" TEXT,
+    "shareSizeLimit" TEXT,
+    "storageQuotaLimit" TEXT,
+    "allowShare" BOOLEAN NOT NULL DEFAULT true,
+    "allowCreateReverseShares" BOOLEAN NOT NULL DEFAULT true,
+    "maxShares" INTEGER,
+    "maxReverseShares" INTEGER,
+    "totpEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "totpVerified" BOOLEAN NOT NULL DEFAULT false,
+    "totpSecret" TEXT,
+    "isActivated" BOOLEAN NOT NULL DEFAULT true,
+    "activationToken" TEXT,
+    "activationTokenExpiresAt" DATETIME
+);
+INSERT INTO "new_User" ("activationToken", "activationTokenExpiresAt", "createdAt", "email", "id", "isActivated", "isAdmin", "ldapDN", "password", "shareSizeLimit", "storageQuotaLimit", "totpEnabled", "totpSecret", "totpVerified", "updatedAt", "username") SELECT "activationToken", "activationTokenExpiresAt", "createdAt", "email", "id", "isActivated", "isAdmin", "ldapDN", "password", "shareSizeLimit", "storageQuotaLimit", "totpEnabled", "totpSecret", "totpVerified", "updatedAt", "username" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_username_key" ON "User"("username");
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+CREATE UNIQUE INDEX "User_ldapDN_key" ON "User"("ldapDN");
+CREATE UNIQUE INDEX "User_activationToken_key" ON "User"("activationToken");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,6 +19,10 @@ model User {
   ldapDN   String? @unique
   shareSizeLimit String?
   storageQuotaLimit String?
+  allowShare Boolean @default(true)
+  allowCreateReverseShares Boolean @default(true)
+  maxShares Int?
+  maxReverseShares Int?
 
   shares              Share[]
   refreshTokens       RefreshToken[]

--- a/backend/src/i18n/en-US/reverseShare.json
+++ b/backend/src/i18n/en-US/reverseShare.json
@@ -1,5 +1,7 @@
 {
   "notFound": "Reverse share token not found",
   "maxShareSizeExceeded": "Max share size can't be greater than {maxSize} bytes.",
-  "tokenInUse": "Reverse share token already in use"
+  "tokenInUse": "Reverse share token already in use",
+  "notAllowedToCreate": "You do not have permission to create reverse shares",
+  "maxReverseSharesExceeded": "Maximum active reverse shares limit ({max}) reached"
 }

--- a/backend/src/i18n/en-US/share.json
+++ b/backend/src/i18n/en-US/share.json
@@ -15,5 +15,7 @@
   "tokenRequired": "Share token required",
   "privateShare": "Only reverse share creator can access this share",
   "maxViewsExceeded": "Maximum views exceeded",
-  "restrictedToRecipients": "This share is restricted to specific recipients. Please log in to access it."
+  "restrictedToRecipients": "This share is restricted to specific recipients. Please log in to access it.",
+  "notAllowedToShare": "You do not have permission to create shares",
+  "maxSharesExceeded": "Maximum active shares limit ({max}) reached"
 }

--- a/backend/src/reverseShare/reverseShare.service.ts
+++ b/backend/src/reverseShare/reverseShare.service.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, Injectable } from "@nestjs/common";
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+} from "@nestjs/common";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import * as moment from "moment";
 import { I18nService } from "nestjs-i18n";
@@ -31,6 +35,29 @@ export class ReverseShareService {
     const creator = await this.prisma.user.findUnique({
       where: { id: creatorId },
     });
+    if (!creator) throw new BadRequestException(this.i18n.t("auth.userNotFound"));
+
+    if (creator.allowCreateReverseShares === false) {
+      throw new ForbiddenException(
+        this.i18n.t("reverseShare.notAllowedToCreate"),
+      );
+    }
+
+    if (creator.maxReverseShares != null && creator.maxReverseShares > 0) {
+      const activeReverseSharesCount = await this.prisma.reverseShare.count({
+        where: {
+          creatorId,
+          shareExpiration: { gt: new Date() },
+        },
+      });
+      if (activeReverseSharesCount >= creator.maxReverseShares) {
+        throw new BadRequestException(
+          this.i18n.t("reverseShare.maxReverseSharesExceeded", {
+            args: { max: creator.maxReverseShares },
+          }),
+        );
+      }
+    }
 
     const parsedExpiration = parseRelativeDateToAbsolute(data.shareExpiration);
     const maxExpiration = this.config.get("share.maxExpiration");

--- a/backend/src/share/share.service.ts
+++ b/backend/src/share/share.service.ts
@@ -46,6 +46,32 @@ export class ShareService {
       await this.reverseShareService.getByToken(reverseShareToken);
     const quotaOwner = reverseShare ? reverseShare.creator : user;
 
+    if (!reverseShare && user) {
+      if (user.allowShare === false) {
+        throw new ForbiddenException(this.i18n.t("share.notAllowedToShare"));
+      }
+
+      if (user.maxShares != null && user.maxShares > 0) {
+        const activeSharesCount = await this.prisma.share.count({
+          where: {
+            creatorId: user.id,
+            uploadLocked: true,
+            OR: [
+              { expiration: { gt: new Date() } },
+              { expiration: { equals: moment(0).toDate() } },
+            ],
+          },
+        });
+        if (activeSharesCount >= user.maxShares) {
+          throw new BadRequestException(
+            this.i18n.t("share.maxSharesExceeded", {
+              args: { max: user.maxShares },
+            }),
+          );
+        }
+      }
+    }
+
     if (share.size) {
       const systemInfo = await this.systemService.getSystemInfo();
       if (systemInfo && systemInfo.total - systemInfo.used < share.size) {

--- a/backend/src/share/share.service.ts
+++ b/backend/src/share/share.service.ts
@@ -228,6 +228,32 @@ export class ShareService {
         this.i18n.t("share.completionRequiresFile"),
       );
 
+    if (!share.reverseShare && share.creator) {
+      if (share.creator.allowShare === false) {
+        throw new ForbiddenException(this.i18n.t("share.notAllowedToShare"));
+      }
+
+      if (share.creator.maxShares != null && share.creator.maxShares > 0) {
+        const activeSharesCount = await this.prisma.share.count({
+          where: {
+            creatorId: share.creator.id,
+            uploadLocked: true,
+            OR: [
+              { expiration: { gt: new Date() } },
+              { expiration: { equals: moment(0).toDate() } },
+            ],
+          },
+        });
+        if (activeSharesCount >= share.creator.maxShares) {
+          throw new BadRequestException(
+            this.i18n.t("share.maxSharesExceeded", {
+              args: { max: share.creator.maxShares },
+            }),
+          );
+        }
+      }
+    }
+
     // Asynchronously create a zip of all files
     if (share.files.length > 1)
       this.createZip(id).then(() =>

--- a/backend/src/user/dto/createUser.dto.ts
+++ b/backend/src/user/dto/createUser.dto.ts
@@ -14,6 +14,22 @@ export class CreateUserDTO extends UserDTO {
   @IsOptional()
   password: string;
 
+  @Allow()
+  @IsOptional()
+  allowShare: boolean;
+
+  @Allow()
+  @IsOptional()
+  allowCreateReverseShares: boolean;
+
+  @Allow()
+  @IsOptional()
+  maxShares?: number;
+
+  @Allow()
+  @IsOptional()
+  maxReverseShares?: number;
+
   from(partial: Partial<CreateUserDTO>) {
     return plainToClass(CreateUserDTO, partial, {
       excludeExtraneousValues: true,

--- a/backend/src/user/dto/createUser.dto.ts
+++ b/backend/src/user/dto/createUser.dto.ts
@@ -14,22 +14,6 @@ export class CreateUserDTO extends UserDTO {
   @IsOptional()
   password: string;
 
-  @Allow()
-  @IsOptional()
-  allowShare: boolean;
-
-  @Allow()
-  @IsOptional()
-  allowCreateReverseShares: boolean;
-
-  @Allow()
-  @IsOptional()
-  maxShares?: number;
-
-  @Allow()
-  @IsOptional()
-  maxReverseShares?: number;
-
   from(partial: Partial<CreateUserDTO>) {
     return plainToClass(CreateUserDTO, partial, {
       excludeExtraneousValues: true,

--- a/backend/src/user/dto/user.dto.ts
+++ b/backend/src/user/dto/user.dto.ts
@@ -1,9 +1,12 @@
 import { Expose, plainToClass } from "class-transformer";
 import {
+  IsBoolean,
   IsEmail,
+  IsInt,
   IsOptional,
   Length,
   Matches,
+  Min,
   MinLength,
 } from "class-validator";
 import { i18nValidationMessage } from "nestjs-i18n";
@@ -53,6 +56,28 @@ export class UserDTO {
     message: "storageQuotaLimit must be greater than 0",
   })
   storageQuotaLimit?: string;
+
+  @Expose()
+  @IsOptional()
+  @IsBoolean()
+  allowShare: boolean;
+
+  @Expose()
+  @IsOptional()
+  @IsBoolean()
+  allowCreateReverseShares: boolean;
+
+  @Expose()
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  maxShares?: number;
+
+  @Expose()
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  maxReverseShares?: number;
 
   @Expose()
   totpVerified: boolean;

--- a/frontend/src/components/admin/users/showCreateUserModal.tsx
+++ b/frontend/src/components/admin/users/showCreateUserModal.tsx
@@ -1,14 +1,17 @@
 import {
   Button,
   Group,
+  NumberInput,
   PasswordInput,
   Stack,
   Switch,
+  Tabs,
   TextInput,
 } from "@mantine/core";
 import { useForm, yupResolver } from "@mantine/form";
 import { ModalsContextProps } from "@mantine/modals/lib/context";
 import { FormattedMessage } from "react-intl";
+import { TbLock, TbUser } from "react-icons/tb";
 import * as yup from "yup";
 import useTranslate from "../../../hooks/useTranslate.hook";
 import userService from "../../../services/user.service";
@@ -25,7 +28,12 @@ const showCreateUserModal = (
   return modals.openModal({
     title: "Create user",
     children: (
-      <Body modals={modals} smtpEnabled={smtpEnabled} getUsers={getUsers} customPasswordPolicy={customPasswordPolicy} />
+      <Body
+        modals={modals}
+        smtpEnabled={smtpEnabled}
+        getUsers={getUsers}
+        customPasswordPolicy={customPasswordPolicy}
+      />
     ),
   });
 };
@@ -50,6 +58,12 @@ const Body = ({
       password: undefined,
       isAdmin: false,
       setPasswordManually: false,
+      allowShare: true,
+      allowCreateReverseShares: true,
+      hasCustomMaxShares: false,
+      maxShares: 10,
+      hasCustomMaxReverseShares: false,
+      maxReverseShares: 5,
       hasCustomShareSizeLimit: false,
       shareSizeLimit: 104857600,
       hasCustomStorageQuotaLimit: false,
@@ -63,13 +77,52 @@ const Body = ({
           .min(3, t("common.error.too-short", { length: 3 })),
         password: yup
           .string()
-          .min(customPasswordPolicy.minLength, t("common.error.too-short", { length: customPasswordPolicy.minLength }))
-          .matches(customPasswordPolicy.requireLowercase ? /[a-z]/ : /.*/, t("common.error.password.lowercase"))
-          .matches(customPasswordPolicy.requireUppercase ? /[A-Z]/ : /.*/, t("common.error.password.uppercase"))
-          .matches(customPasswordPolicy.requireNumber ? /[0-9]/ : /.*/, t("common.error.password.number"))
-          .matches(customPasswordPolicy.requireSpecialCharacter ? /[^a-zA-Z0-9]/ : /.*/, t("common.error.password.special"))
+          .min(
+            customPasswordPolicy.minLength,
+            t("common.error.too-short", {
+              length: customPasswordPolicy.minLength,
+            }),
+          )
+          .matches(
+            customPasswordPolicy.requireLowercase ? /[a-z]/ : /.*/,
+            t("common.error.password.lowercase"),
+          )
+          .matches(
+            customPasswordPolicy.requireUppercase ? /[A-Z]/ : /.*/,
+            t("common.error.password.uppercase"),
+          )
+          .matches(
+            customPasswordPolicy.requireNumber ? /[0-9]/ : /.*/,
+            t("common.error.password.number"),
+          )
+          .matches(
+            customPasswordPolicy.requireSpecialCharacter
+              ? /[^a-zA-Z0-9]/
+              : /.*/,
+            t("common.error.password.special"),
+          )
           .required(t("common.error.field-required"))
           .optional(),
+        maxShares: yup
+          .number()
+          .test(
+            "max-shares-positive",
+            "Max active shares must be at least 1",
+            function (value) {
+              if (!this.parent.hasCustomMaxShares) return true;
+              return (value ?? 0) >= 1;
+            },
+          ),
+        maxReverseShares: yup
+          .number()
+          .test(
+            "max-reverse-shares-positive",
+            "Max active reverse shares must be at least 1",
+            function (value) {
+              if (!this.parent.hasCustomMaxReverseShares) return true;
+              return (value ?? 0) >= 1;
+            },
+          ),
         storageQuotaLimit: yup
           .number()
           .test(
@@ -87,6 +140,7 @@ const Body = ({
   return (
     <Stack>
       <form
+        id="createUserForm"
         onSubmit={form.onSubmit(async (values) => {
           userService
             .create({
@@ -94,6 +148,12 @@ const Body = ({
               email: values.email,
               password: values.password,
               isAdmin: values.isAdmin,
+              allowShare: values.allowShare,
+              allowCreateReverseShares: values.allowCreateReverseShares,
+              maxShares: values.hasCustomMaxShares ? values.maxShares : null,
+              maxReverseShares: values.hasCustomMaxReverseShares
+                ? values.maxReverseShares
+                : null,
               shareSizeLimit: values.hasCustomShareSizeLimit
                 ? values.shareSizeLimit.toString()
                 : null,
@@ -108,102 +168,211 @@ const Body = ({
             .catch(toast.axiosError);
         })}
       >
-        <Stack>
-          <TextInput
-            label={t("admin.users.modal.create.username")}
-            {...form.getInputProps("username")}
-          />
-          <TextInput
-            label={t("admin.users.modal.create.email")}
-            {...form.getInputProps("email")}
-          />
-          {smtpEnabled && (
-            <Switch
-              mt="xs"
-              labelPosition="left"
-              label={t("admin.users.modal.create.manual-password")}
-              description={t(
-                "admin.users.modal.create.manual-password.description",
+        <Tabs defaultValue="general">
+          <Tabs.List mb="md">
+            <Tabs.Tab value="general" icon={<TbUser size={16} />}>
+              <FormattedMessage id="admin.users.edit.tabs.general" />
+            </Tabs.Tab>
+            <Tabs.Tab value="permissions" icon={<TbLock size={16} />}>
+              <FormattedMessage id="admin.users.edit.tabs.permissions" />
+            </Tabs.Tab>
+          </Tabs.List>
+
+          <Tabs.Panel value="general">
+            <Stack>
+              <TextInput
+                label={t("admin.users.modal.create.username")}
+                {...form.getInputProps("username")}
+              />
+              <TextInput
+                label={t("admin.users.modal.create.email")}
+                {...form.getInputProps("email")}
+              />
+              {smtpEnabled && (
+                <Switch
+                  mt="xs"
+                  labelPosition="left"
+                  label={t("admin.users.modal.create.manual-password")}
+                  description={t(
+                    "admin.users.modal.create.manual-password.description",
+                  )}
+                  {...form.getInputProps("setPasswordManually", {
+                    type: "checkbox",
+                  })}
+                />
               )}
-              {...form.getInputProps("setPasswordManually", {
-                type: "checkbox",
-              })}
-            />
-          )}
-          {(form.values.setPasswordManually || !smtpEnabled) && (
-            <PasswordInput
-              label={t("admin.users.modal.create.password")}
-              {...form.getInputProps("password")}
-            />
-          )}
-          <Switch
-            styles={{
-              body: {
-                display: "flex",
-                justifyContent: "space-between",
-              },
-            }}
-            mt="xs"
-            labelPosition="left"
-            label={t("admin.users.modal.create.custom-share-size-limit")}
-            description={t(
-              "admin.users.modal.create.custom-share-size-limit.description",
-            )}
-            {...form.getInputProps("hasCustomShareSizeLimit", {
-              type: "checkbox",
-            })}
-          />
-          {form.values.hasCustomShareSizeLimit && (
-            <FileSizeInput
-              label={t("admin.users.modal.create.custom-share-size-limit")}
-              value={form.values.shareSizeLimit}
-              onChange={(val) => form.setFieldValue("shareSizeLimit", val)}
-            />
-          )}
-          <Switch
-            styles={{
-              body: {
-                display: "flex",
-                justifyContent: "space-between",
-              },
-            }}
-            mt="xs"
-            labelPosition="left"
-            label={t("admin.users.modal.create.custom-storage-quota-limit")}
-            description={t(
-              "admin.users.modal.create.custom-storage-quota-limit.description",
-            )}
-            {...form.getInputProps("hasCustomStorageQuotaLimit", {
-              type: "checkbox",
-            })}
-          />
-          {form.values.hasCustomStorageQuotaLimit && (
-            <FileSizeInput
-              label={t("admin.users.modal.create.custom-storage-quota-limit")}
-              value={form.values.storageQuotaLimit}
-              onChange={(val) => form.setFieldValue("storageQuotaLimit", val)}
-            />
-          )}
-          <Switch
-            styles={{
-              body: {
-                display: "flex",
-                justifyContent: "space-between",
-              },
-            }}
-            mt="xs"
-            labelPosition="left"
-            label={t("admin.users.modal.create.admin")}
-            description={t("admin.users.modal.create.admin.description")}
-            {...form.getInputProps("isAdmin", { type: "checkbox" })}
-          />
-          <Group position="right">
-            <Button type="submit">
-              <FormattedMessage id="common.button.create" />
-            </Button>
-          </Group>
-        </Stack>
+              {(form.values.setPasswordManually || !smtpEnabled) && (
+                <PasswordInput
+                  label={t("admin.users.modal.create.password")}
+                  {...form.getInputProps("password")}
+                />
+              )}
+              <Switch
+                styles={{
+                  body: {
+                    display: "flex",
+                    justifyContent: "space-between",
+                  },
+                }}
+                mt="xs"
+                labelPosition="left"
+                label={t("admin.users.modal.create.admin")}
+                description={t("admin.users.modal.create.admin.description")}
+                {...form.getInputProps("isAdmin", { type: "checkbox" })}
+              />
+            </Stack>
+          </Tabs.Panel>
+
+          <Tabs.Panel value="permissions">
+            <Stack>
+              <Switch
+                styles={{
+                  body: {
+                    display: "flex",
+                    justifyContent: "space-between",
+                  },
+                }}
+                labelPosition="left"
+                label={t("admin.users.edit.permissions.allow-share")}
+                description={t(
+                  "admin.users.edit.permissions.allow-share.description",
+                )}
+                {...form.getInputProps("allowShare", {
+                  type: "checkbox",
+                })}
+              />
+              <Switch
+                styles={{
+                  body: {
+                    display: "flex",
+                    justifyContent: "space-between",
+                  },
+                }}
+                mt="xs"
+                labelPosition="left"
+                label={t("admin.users.edit.permissions.allow-reverse-share")}
+                description={t(
+                  "admin.users.edit.permissions.allow-reverse-share.description",
+                )}
+                {...form.getInputProps("allowCreateReverseShares", {
+                  type: "checkbox",
+                })}
+              />
+              <Switch
+                styles={{
+                  body: {
+                    display: "flex",
+                    justifyContent: "space-between",
+                  },
+                }}
+                mt="xs"
+                labelPosition="left"
+                label={t("admin.users.edit.permissions.custom-max-shares")}
+                description={t(
+                  "admin.users.edit.permissions.custom-max-shares.description",
+                )}
+                {...form.getInputProps("hasCustomMaxShares", {
+                  type: "checkbox",
+                })}
+              />
+              {form.values.hasCustomMaxShares && (
+                <NumberInput
+                  label={t("admin.users.edit.permissions.custom-max-shares")}
+                  min={1}
+                  step={1}
+                  {...form.getInputProps("maxShares")}
+                />
+              )}
+              <Switch
+                styles={{
+                  body: {
+                    display: "flex",
+                    justifyContent: "space-between",
+                  },
+                }}
+                mt="xs"
+                labelPosition="left"
+                label={t(
+                  "admin.users.edit.permissions.custom-max-reverse-shares",
+                )}
+                description={t(
+                  "admin.users.edit.permissions.custom-max-reverse-shares.description",
+                )}
+                {...form.getInputProps("hasCustomMaxReverseShares", {
+                  type: "checkbox",
+                })}
+              />
+              {form.values.hasCustomMaxReverseShares && (
+                <NumberInput
+                  label={t(
+                    "admin.users.edit.permissions.custom-max-reverse-shares",
+                  )}
+                  min={1}
+                  step={1}
+                  {...form.getInputProps("maxReverseShares")}
+                />
+              )}
+              <Switch
+                styles={{
+                  body: {
+                    display: "flex",
+                    justifyContent: "space-between",
+                  },
+                }}
+                mt="xs"
+                labelPosition="left"
+                label={t("admin.users.edit.update.custom-share-size-limit")}
+                description={t(
+                  "admin.users.edit.update.custom-share-size-limit.description",
+                )}
+                {...form.getInputProps("hasCustomShareSizeLimit", {
+                  type: "checkbox",
+                })}
+              />
+              {form.values.hasCustomShareSizeLimit && (
+                <FileSizeInput
+                  label={t("admin.users.edit.update.custom-share-size-limit")}
+                  value={form.values.shareSizeLimit}
+                  onChange={(val) => form.setFieldValue("shareSizeLimit", val)}
+                />
+              )}
+              <Switch
+                styles={{
+                  body: {
+                    display: "flex",
+                    justifyContent: "space-between",
+                  },
+                }}
+                mt="xs"
+                labelPosition="left"
+                label={t("admin.users.edit.update.custom-storage-quota-limit")}
+                description={t(
+                  "admin.users.edit.update.custom-storage-quota-limit.description",
+                )}
+                {...form.getInputProps("hasCustomStorageQuotaLimit", {
+                  type: "checkbox",
+                })}
+              />
+              {form.values.hasCustomStorageQuotaLimit && (
+                <FileSizeInput
+                  label={t(
+                    "admin.users.edit.update.custom-storage-quota-limit",
+                  )}
+                  value={form.values.storageQuotaLimit}
+                  onChange={(val) =>
+                    form.setFieldValue("storageQuotaLimit", val)
+                  }
+                />
+              )}
+            </Stack>
+          </Tabs.Panel>
+        </Tabs>
       </form>
+      <Group position="right">
+        <Button type="submit" form="createUserForm">
+          <FormattedMessage id="common.button.create" />
+        </Button>
+      </Group>
     </Stack>
   );
 };

--- a/frontend/src/components/admin/users/showCreateUserModal.tsx
+++ b/frontend/src/components/admin/users/showCreateUserModal.tsx
@@ -12,6 +12,7 @@ import { useForm, yupResolver } from "@mantine/form";
 import { ModalsContextProps } from "@mantine/modals/lib/context";
 import { FormattedMessage } from "react-intl";
 import { TbLock, TbUser } from "react-icons/tb";
+import { useState } from "react";
 import * as yup from "yup";
 import useTranslate from "../../../hooks/useTranslate.hook";
 import userService from "../../../services/user.service";
@@ -50,6 +51,7 @@ const Body = ({
   customPasswordPolicy: CustomPasswordPolicy;
 }) => {
   const t = useTranslate();
+  const [activeTab, setActiveTab] = useState<string | null>("general");
 
   const form = useForm({
     initialValues: {
@@ -105,6 +107,7 @@ const Body = ({
           .optional(),
         maxShares: yup
           .number()
+          .transform((value) => value || 0)
           .test(
             "max-shares-positive",
             "Max active shares must be at least 1",
@@ -115,6 +118,7 @@ const Body = ({
           ),
         maxReverseShares: yup
           .number()
+          .transform((value) => value || 0)
           .test(
             "max-reverse-shares-positive",
             "Max active reverse shares must be at least 1",
@@ -166,9 +170,15 @@ const Body = ({
               modals.closeAll();
             })
             .catch(toast.axiosError);
+        }, (errors) => {
+          if (errors.username || errors.email || errors.password) {
+            setActiveTab("general");
+          } else {
+            setActiveTab("permissions");
+          }
         })}
       >
-        <Tabs defaultValue="general">
+        <Tabs value={activeTab} onTabChange={setActiveTab}>
           <Tabs.List mb="md">
             <Tabs.Tab value="general" icon={<TbUser size={16} />}>
               <FormattedMessage id="admin.users.edit.tabs.general" />

--- a/frontend/src/components/admin/users/showUpdateUserModal.tsx
+++ b/frontend/src/components/admin/users/showUpdateUserModal.tsx
@@ -13,6 +13,7 @@ import { useForm, yupResolver } from "@mantine/form";
 import { ModalsContextProps } from "@mantine/modals/lib/context";
 import { FormattedMessage } from "react-intl";
 import { TbLock, TbUser } from "react-icons/tb";
+import { useState } from "react";
 import * as yup from "yup";
 import useTranslate, {
   translateOutsideContext,
@@ -55,6 +56,7 @@ const Body = ({
   customPasswordPolicy: CustomPasswordPolicy;
 }) => {
   const t = useTranslate();
+  const [activeTab, setActiveTab] = useState<string | null>("general");
 
   const accountForm = useForm({
     initialValues: {
@@ -86,6 +88,7 @@ const Body = ({
           .min(3, t("common.error.too-short", { length: 3 })),
         maxShares: yup
           .number()
+          .transform((value) => value || 0)
           .test(
             "max-shares-positive",
             "Max active shares must be at least 1",
@@ -96,6 +99,7 @@ const Body = ({
           ),
         maxReverseShares: yup
           .number()
+          .transform((value) => value || 0)
           .test(
             "max-reverse-shares-positive",
             "Max active reverse shares must be at least 1",
@@ -184,9 +188,15 @@ const Body = ({
               modals.closeAll();
             })
             .catch(toast.axiosError);
+        }, (errors) => {
+          if (errors.username || errors.email) {
+            setActiveTab("general");
+          } else {
+            setActiveTab("permissions");
+          }
         })}
       >
-        <Tabs defaultValue="general">
+        <Tabs value={activeTab} onTabChange={setActiveTab}>
           <Tabs.List mb="md">
             <Tabs.Tab value="general" icon={<TbUser size={16} />}>
               <FormattedMessage id="admin.users.edit.tabs.general" />

--- a/frontend/src/components/admin/users/showUpdateUserModal.tsx
+++ b/frontend/src/components/admin/users/showUpdateUserModal.tsx
@@ -2,14 +2,17 @@ import {
   Accordion,
   Button,
   Group,
+  NumberInput,
   PasswordInput,
   Stack,
   Switch,
+  Tabs,
   TextInput,
 } from "@mantine/core";
 import { useForm, yupResolver } from "@mantine/form";
 import { ModalsContextProps } from "@mantine/modals/lib/context";
 import { FormattedMessage } from "react-intl";
+import { TbLock, TbUser } from "react-icons/tb";
 import * as yup from "yup";
 import useTranslate, {
   translateOutsideContext,
@@ -59,6 +62,13 @@ const Body = ({
       email: user.email,
       isAdmin: user.isAdmin,
       isActivated: user.isActivated,
+      allowShare: user.allowShare ?? true,
+      allowCreateReverseShares: user.allowCreateReverseShares ?? true,
+      hasCustomMaxShares: user.maxShares != null && user.maxShares > 0,
+      maxShares: user.maxShares ?? 10,
+      hasCustomMaxReverseShares:
+        user.maxReverseShares != null && user.maxReverseShares > 0,
+      maxReverseShares: user.maxReverseShares ?? 5,
       hasCustomShareSizeLimit: !!user.shareSizeLimit,
       shareSizeLimit: user.shareSizeLimit
         ? parseInt(user.shareSizeLimit)
@@ -74,6 +84,26 @@ const Body = ({
         username: yup
           .string()
           .min(3, t("common.error.too-short", { length: 3 })),
+        maxShares: yup
+          .number()
+          .test(
+            "max-shares-positive",
+            "Max active shares must be at least 1",
+            function (value) {
+              if (!this.parent.hasCustomMaxShares) return true;
+              return (value ?? 0) >= 1;
+            },
+          ),
+        maxReverseShares: yup
+          .number()
+          .test(
+            "max-reverse-shares-positive",
+            "Max active reverse shares must be at least 1",
+            function (value) {
+              if (!this.parent.hasCustomMaxReverseShares) return true;
+              return (value ?? 0) >= 1;
+            },
+          ),
         storageQuotaLimit: yup
           .number()
           .test(
@@ -136,6 +166,12 @@ const Body = ({
               email: values.email,
               isAdmin: values.isAdmin,
               isActivated: values.isActivated,
+              allowShare: values.allowShare,
+              allowCreateReverseShares: values.allowCreateReverseShares,
+              maxShares: values.hasCustomMaxShares ? values.maxShares : null,
+              maxReverseShares: values.hasCustomMaxReverseShares
+                ? values.maxReverseShares
+                : null,
               shareSizeLimit: values.hasCustomShareSizeLimit
                 ? values.shareSizeLimit.toString()
                 : null,
@@ -150,115 +186,233 @@ const Body = ({
             .catch(toast.axiosError);
         })}
       >
-        <Stack>
-          <TextInput
-            label={t("admin.users.table.username")}
-            {...accountForm.getInputProps("username")}
-          />
-          <TextInput
-            label={t("admin.users.table.email")}
-            {...accountForm.getInputProps("email")}
-          />
-          <Switch
-            mt="xs"
-            labelPosition="left"
-            label={t("admin.users.edit.update.admin-privileges")}
-            {...accountForm.getInputProps("isAdmin", { type: "checkbox" })}
-          />
-          <Switch
-            mt="xs"
-            labelPosition="left"
-            label={t("admin.users.edit.update.email-verified")}
-            {...accountForm.getInputProps("isActivated", { type: "checkbox" })}
-            disabled={user.isActivated}
-          />
-          <Switch
-            styles={{
-              body: {
-                display: "flex",
-                justifyContent: "space-between",
-              },
-            }}
-            mt="xs"
-            labelPosition="left"
-            label={t("admin.users.edit.update.custom-share-size-limit")}
-            description={t(
-              "admin.users.edit.update.custom-share-size-limit.description",
-            )}
-            {...accountForm.getInputProps("hasCustomShareSizeLimit", {
-              type: "checkbox",
-            })}
-          />
-          {accountForm.values.hasCustomShareSizeLimit && (
-            <FileSizeInput
-              label={t("admin.users.edit.update.custom-share-size-limit")}
-              value={accountForm.values.shareSizeLimit}
-              onChange={(val) =>
-                accountForm.setFieldValue("shareSizeLimit", val)
-              }
-            />
-          )}
-          <Switch
-            styles={{
-              body: {
-                display: "flex",
-                justifyContent: "space-between",
-              },
-            }}
-            mt="xs"
-            labelPosition="left"
-            label={t("admin.users.edit.update.custom-storage-quota-limit")}
-            description={t(
-              "admin.users.edit.update.custom-storage-quota-limit.description",
-            )}
-            {...accountForm.getInputProps("hasCustomStorageQuotaLimit", {
-              type: "checkbox",
-            })}
-          />
-          {accountForm.values.hasCustomStorageQuotaLimit && (
-            <FileSizeInput
-              label={t("admin.users.edit.update.custom-storage-quota-limit")}
-              value={accountForm.values.storageQuotaLimit}
-              onChange={(val) =>
-                accountForm.setFieldValue("storageQuotaLimit", val)
-              }
-            />
-          )}
-        </Stack>
-      </form>
-      <Accordion>
-        <Accordion.Item sx={{ borderBottom: "none" }} value="changePassword">
-          <Accordion.Control px={0}>
-            <FormattedMessage id="admin.users.edit.update.change-password.title" />
-          </Accordion.Control>
-          <Accordion.Panel>
-            <form
-              onSubmit={passwordForm.onSubmit(async (values) => {
-                userService
-                  .update(user.id, {
-                    password: values.password,
-                  })
-                  .then(() =>
-                    toast.success(
-                      t("admin.users.edit.update.notify.password.success"),
-                    ),
-                  )
-                  .catch(toast.axiosError);
-              })}
-            >
-              <Stack>
-                <PasswordInput
-                  label={t("admin.users.edit.update.change-password.field")}
-                  {...passwordForm.getInputProps("password")}
+        <Tabs defaultValue="general">
+          <Tabs.List mb="md">
+            <Tabs.Tab value="general" icon={<TbUser size={16} />}>
+              <FormattedMessage id="admin.users.edit.tabs.general" />
+            </Tabs.Tab>
+            <Tabs.Tab value="permissions" icon={<TbLock size={16} />}>
+              <FormattedMessage id="admin.users.edit.tabs.permissions" />
+            </Tabs.Tab>
+          </Tabs.List>
+
+          <Tabs.Panel value="general">
+            <Stack>
+              <TextInput
+                label={t("admin.users.table.username")}
+                {...accountForm.getInputProps("username")}
+              />
+              <TextInput
+                label={t("admin.users.table.email")}
+                {...accountForm.getInputProps("email")}
+              />
+              <Switch
+                mt="xs"
+                labelPosition="left"
+                label={t("admin.users.edit.update.admin-privileges")}
+                {...accountForm.getInputProps("isAdmin", { type: "checkbox" })}
+              />
+              <Switch
+                mt="xs"
+                labelPosition="left"
+                label={t("admin.users.edit.update.email-verified")}
+                {...accountForm.getInputProps("isActivated", {
+                  type: "checkbox",
+                })}
+                disabled={user.isActivated}
+              />
+              <Accordion mt="md">
+                <Accordion.Item
+                  sx={{ borderBottom: "none" }}
+                  value="changePassword"
+                >
+                  <Accordion.Control px={0}>
+                    <FormattedMessage id="admin.users.edit.update.change-password.title" />
+                  </Accordion.Control>
+                  <Accordion.Panel>
+                    <Stack>
+                      <PasswordInput
+                        label={t(
+                          "admin.users.edit.update.change-password.field",
+                        )}
+                        {...passwordForm.getInputProps("password")}
+                      />
+                      <Button
+                        variant="light"
+                        type="button"
+                        onClick={() => {
+                          passwordForm.onSubmit(async (values) => {
+                            userService
+                              .update(user.id, {
+                                password: values.password,
+                              })
+                              .then(() =>
+                                toast.success(
+                                  t(
+                                    "admin.users.edit.update.notify.password.success",
+                                  ),
+                                ),
+                              )
+                              .catch(toast.axiosError);
+                          })();
+                        }}
+                      >
+                        <FormattedMessage id="admin.users.edit.update.change-password.button" />
+                      </Button>
+                    </Stack>
+                  </Accordion.Panel>
+                </Accordion.Item>
+              </Accordion>
+            </Stack>
+          </Tabs.Panel>
+
+          <Tabs.Panel value="permissions">
+            <Stack>
+              <Switch
+                styles={{
+                  body: {
+                    display: "flex",
+                    justifyContent: "space-between",
+                  },
+                }}
+                labelPosition="left"
+                label={t("admin.users.edit.permissions.allow-share")}
+                description={t(
+                  "admin.users.edit.permissions.allow-share.description",
+                )}
+                {...accountForm.getInputProps("allowShare", {
+                  type: "checkbox",
+                })}
+              />
+              <Switch
+                styles={{
+                  body: {
+                    display: "flex",
+                    justifyContent: "space-between",
+                  },
+                }}
+                mt="xs"
+                labelPosition="left"
+                label={t("admin.users.edit.permissions.allow-reverse-share")}
+                description={t(
+                  "admin.users.edit.permissions.allow-reverse-share.description",
+                )}
+                {...accountForm.getInputProps("allowCreateReverseShares", {
+                  type: "checkbox",
+                })}
+              />
+              <Switch
+                styles={{
+                  body: {
+                    display: "flex",
+                    justifyContent: "space-between",
+                  },
+                }}
+                mt="xs"
+                labelPosition="left"
+                label={t("admin.users.edit.permissions.custom-max-shares")}
+                description={t(
+                  "admin.users.edit.permissions.custom-max-shares.description",
+                )}
+                {...accountForm.getInputProps("hasCustomMaxShares", {
+                  type: "checkbox",
+                })}
+              />
+              {accountForm.values.hasCustomMaxShares && (
+                <NumberInput
+                  label={t("admin.users.edit.permissions.custom-max-shares")}
+                  min={1}
+                  step={1}
+                  {...accountForm.getInputProps("maxShares")}
                 />
-                <Button variant="light" type="submit">
-                  <FormattedMessage id="admin.users.edit.update.change-password.button" />
-                </Button>
-              </Stack>
-            </form>
-          </Accordion.Panel>
-        </Accordion.Item>
-      </Accordion>
+              )}
+              <Switch
+                styles={{
+                  body: {
+                    display: "flex",
+                    justifyContent: "space-between",
+                  },
+                }}
+                mt="xs"
+                labelPosition="left"
+                label={t(
+                  "admin.users.edit.permissions.custom-max-reverse-shares",
+                )}
+                description={t(
+                  "admin.users.edit.permissions.custom-max-reverse-shares.description",
+                )}
+                {...accountForm.getInputProps("hasCustomMaxReverseShares", {
+                  type: "checkbox",
+                })}
+              />
+              {accountForm.values.hasCustomMaxReverseShares && (
+                <NumberInput
+                  label={t(
+                    "admin.users.edit.permissions.custom-max-reverse-shares",
+                  )}
+                  min={1}
+                  step={1}
+                  {...accountForm.getInputProps("maxReverseShares")}
+                />
+              )}
+              <Switch
+                styles={{
+                  body: {
+                    display: "flex",
+                    justifyContent: "space-between",
+                  },
+                }}
+                mt="xs"
+                labelPosition="left"
+                label={t("admin.users.edit.update.custom-share-size-limit")}
+                description={t(
+                  "admin.users.edit.update.custom-share-size-limit.description",
+                )}
+                {...accountForm.getInputProps("hasCustomShareSizeLimit", {
+                  type: "checkbox",
+                })}
+              />
+              {accountForm.values.hasCustomShareSizeLimit && (
+                <FileSizeInput
+                  label={t("admin.users.edit.update.custom-share-size-limit")}
+                  value={accountForm.values.shareSizeLimit}
+                  onChange={(val) =>
+                    accountForm.setFieldValue("shareSizeLimit", val)
+                  }
+                />
+              )}
+              <Switch
+                styles={{
+                  body: {
+                    display: "flex",
+                    justifyContent: "space-between",
+                  },
+                }}
+                mt="xs"
+                labelPosition="left"
+                label={t("admin.users.edit.update.custom-storage-quota-limit")}
+                description={t(
+                  "admin.users.edit.update.custom-storage-quota-limit.description",
+                )}
+                {...accountForm.getInputProps("hasCustomStorageQuotaLimit", {
+                  type: "checkbox",
+                })}
+              />
+              {accountForm.values.hasCustomStorageQuotaLimit && (
+                <FileSizeInput
+                  label={t(
+                    "admin.users.edit.update.custom-storage-quota-limit",
+                  )}
+                  value={accountForm.values.storageQuotaLimit}
+                  onChange={(val) =>
+                    accountForm.setFieldValue("storageQuotaLimit", val)
+                  }
+                />
+              )}
+            </Stack>
+          </Tabs.Panel>
+        </Tabs>
+      </form>
       <Group position="right">
         <Button type="submit" form="accountForm">
           <FormattedMessage id="common.button.save" />

--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -155,10 +155,14 @@ const Header = () => {
   }, [close, router.pathname]);
 
   const authenticatedLinks: NavLink[] = [
-    {
-      link: "/upload",
-      label: t("navbar.upload"),
-    },
+    ...(user?.allowShare !== false
+      ? [
+          {
+            link: "/upload",
+            label: t("navbar.upload"),
+          },
+        ]
+      : []),
     {
       component: <NavbarShareMenu />,
     },
@@ -195,10 +199,14 @@ const Header = () => {
 
   const mobileRootLinks: NavLink[] = user
     ? [
-        {
-          link: "/upload",
-          label: t("navbar.upload"),
-        },
+        ...(user.allowShare !== false
+          ? [
+              {
+                link: "/upload",
+                label: t("navbar.upload"),
+              },
+            ]
+          : []),
         {
           label: t("common.button.shares"),
         },

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -285,9 +285,25 @@ export default {
   "admin.users.table.storageQuota": "Storage quota",
   "admin.users.table.maxShareSize": "Max share size",
 
+  "admin.users.edit.tabs.general": "General",
+  "admin.users.edit.tabs.permissions": "Permissions",
   "admin.users.edit.update.title": "Edit user: {username}",
   "admin.users.edit.update.admin-privileges": "Admin privileges",
   "admin.users.edit.update.email-verified": "Email verified",
+  "admin.users.edit.permissions.allow-share": "Allow creating shares",
+  "admin.users.edit.permissions.allow-share.description":
+    "Whether this user is allowed to upload and create new shares",
+  "admin.users.edit.permissions.allow-reverse-share":
+    "Allow creating reverse shares",
+  "admin.users.edit.permissions.allow-reverse-share.description":
+    "Whether this user is allowed to generate reverse share links",
+  "admin.users.edit.permissions.custom-max-shares": "Max active shares limit",
+  "admin.users.edit.permissions.custom-max-shares.description":
+    "Limit the maximum number of concurrent active shares this user can have",
+  "admin.users.edit.permissions.custom-max-reverse-shares":
+    "Max active reverse shares limit",
+  "admin.users.edit.permissions.custom-max-reverse-shares.description":
+    "Limit the maximum number of concurrent active reverse shares this user can have",
   "admin.users.edit.update.custom-share-size-limit": "Custom share size limit",
   "admin.users.edit.update.custom-share-size-limit.description":
     "Override the global upload limit for this user",

--- a/frontend/src/i18n/translations/en-US.ts
+++ b/frontend/src/i18n/translations/en-US.ts
@@ -213,6 +213,8 @@ export default {
   "account.reverseShares.title.empty": "It's empty here 👀",
   "account.reverseShares.description.empty":
     "You don't have any reverse shares.",
+  "account.reverseShares.description.not-allowed":
+    "Your account does not have permission to create reverse shares.",
 
   // showCreateReverseShareModal.tsx
   "account.reverseShares.modal.title": "Create reverse share",
@@ -349,6 +351,9 @@ export default {
   "upload.reverse-share.error.invalid.title": "Invalid reverse share link",
   "upload.reverse-share.error.invalid.description":
     "This link has no remaining uses or is invalid.",
+  "upload.error.not-allowed.title": "Share creation not permitted",
+  "upload.error.not-allowed.description":
+    "Your account does not have permission to upload or create shares.",
 
   // Dropzone.tsx
   "upload.dropzone.title": "Upload files",

--- a/frontend/src/pages/account/reverseShares.tsx
+++ b/frontend/src/pages/account/reverseShares.tsx
@@ -72,27 +72,29 @@ const MyShares = () => {
             </ActionIcon>
           </HoverTip>
         </Group>
-        <Button
-          onClick={() =>
-            showCreateReverseShareModal(
-              modals,
-              config.get("smtp.enabled"),
-              user?.isAdmin
-                ? { value: 0, unit: "days" }
-                : config.get("share.maxExpiration"),
-              config.get("share.defaultExpiration"),
-              config.get("share.reverseShareSimpleOnly"),
-              appUrl,
-              defaultAppUrl,
-              userMaxShareSize,
-              getReverseShares,
-              config.get("share.shareIdLength"),
-            )
-          }
-          leftIcon={<TbPlus size={20} />}
-        >
-          <FormattedMessage id="common.button.create" />
-        </Button>
+        {user?.allowCreateReverseShares !== false && (
+          <Button
+            onClick={() =>
+              showCreateReverseShareModal(
+                modals,
+                config.get("smtp.enabled"),
+                user?.isAdmin
+                  ? { value: 0, unit: "days" }
+                  : config.get("share.maxExpiration"),
+                config.get("share.defaultExpiration"),
+                config.get("share.reverseShareSimpleOnly"),
+                appUrl,
+                defaultAppUrl,
+                userMaxShareSize,
+                getReverseShares,
+                config.get("share.shareIdLength"),
+              )
+            }
+            leftIcon={<TbPlus size={20} />}
+          >
+            <FormattedMessage id="common.button.create" />
+          </Button>
+        )}
       </Group>
       {reverseShares.length == 0 ? (
         <Center style={{ height: "70vh" }}>
@@ -100,8 +102,14 @@ const MyShares = () => {
             <Title order={3}>
               <FormattedMessage id="account.reverseShares.title.empty" />
             </Title>
-            <Text>
-              <FormattedMessage id="account.reverseShares.description.empty" />
+            <Text color={user?.allowCreateReverseShares === false ? "dimmed" : undefined} align="center">
+              <FormattedMessage
+                id={
+                  user?.allowCreateReverseShares === false
+                    ? "account.reverseShares.description.not-allowed"
+                    : "account.reverseShares.description.empty"
+                }
+              />
             </Text>
           </Stack>
         </Center>

--- a/frontend/src/pages/account/shares.tsx
+++ b/frontend/src/pages/account/shares.tsx
@@ -69,10 +69,14 @@ const MyShares = () => {
             <Text>
               <FormattedMessage id="account.shares.description.empty" />
             </Text>
-            <Space h={5} />
-            <Button component={Link} href="/upload" variant="light">
-              <FormattedMessage id="account.shares.button.create" />
-            </Button>
+            {user?.allowShare !== false && (
+              <>
+                <Space h={5} />
+                <Button component={Link} href="/upload" variant="light">
+                  <FormattedMessage id="account.shares.button.create" />
+                </Button>
+              </>
+            )}
           </Stack>
         </Center>
       ) : (

--- a/frontend/src/pages/upload/index.tsx
+++ b/frontend/src/pages/upload/index.tsx
@@ -1,9 +1,11 @@
-import { Button, Group } from "@mantine/core";
+import { Button, Center, Group, Space, Stack, Text, Title } from "@mantine/core";
 import { useModals } from "@mantine/modals";
 import { cleanNotifications } from "@mantine/notifications";
 import { AxiosError } from "axios";
 import pLimit from "p-limit";
+import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { TbShieldLock } from "react-icons/tb";
 import { FormattedMessage } from "react-intl";
 import Meta from "../../components/Meta";
 import Dropzone from "../../components/upload/Dropzone";
@@ -301,6 +303,29 @@ const Upload = ({
         .catch(() => toast.error(t("upload.notify.generic-error")));
     }
   }, [files]);
+
+  if (user && user.allowShare === false && !isReverseShare) {
+    return (
+      <>
+        <Meta title={t("upload.title")} />
+        <Center style={{ height: "70vh" }}>
+          <Stack align="center" spacing={10}>
+            <TbShieldLock size={48} color="gray" />
+            <Title order={3}>
+              <FormattedMessage id="upload.error.not-allowed.title" />
+            </Title>
+            <Text color="dimmed" align="center">
+              <FormattedMessage id="upload.error.not-allowed.description" />
+            </Text>
+            <Space h={5} />
+            <Button component={Link} href="/account/shares" variant="light">
+              <FormattedMessage id="account.shares.title" />
+            </Button>
+          </Stack>
+        </Center>
+      </>
+    );
+  }
 
   return (
     <>

--- a/frontend/src/types/user.type.ts
+++ b/frontend/src/types/user.type.ts
@@ -9,6 +9,10 @@ type User = {
   hasPassword: boolean;
   shareSizeLimit?: string;
   storageQuotaLimit?: string;
+  allowShare?: boolean;
+  allowCreateReverseShares?: boolean;
+  maxShares?: number | null;
+  maxReverseShares?: number | null;
 };
 
 export type CreateUser = {
@@ -18,6 +22,10 @@ export type CreateUser = {
   isAdmin?: boolean;
   shareSizeLimit?: string | null;
   storageQuotaLimit?: string | null;
+  allowShare?: boolean;
+  allowCreateReverseShares?: boolean;
+  maxShares?: number | null;
+  maxReverseShares?: number | null;
 };
 
 export type UpdateUser = {
@@ -28,6 +36,10 @@ export type UpdateUser = {
   isActivated?: boolean;
   shareSizeLimit?: string | null;
   storageQuotaLimit?: string | null;
+  allowShare?: boolean;
+  allowCreateReverseShares?: boolean;
+  maxShares?: number | null;
+  maxReverseShares?: number | null;
 };
 
 export type UpdateCurrentUser = {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

## AI Usage
Have you read and does your submission follow the project's [AI Usage Policy](https://github.com/smp46/pingvin-share-x/blob/main/AI_USAGE_POLICY.md)?

- [x] Yes
- [ ] No

Github Copilot was used for autocomplete. Gemini was used to create the tabbed layout in the user modal (create & edit) and for code review.

## What's new?

- Tabbed layout in the modals for creating and editing user accounts (as an Admin on the User Management page). Its now “General” and “Permissions”
  - Custom share size and custom storage quota have been moved to the permissions tab, the rest remains in General.
- New per user permissions (that can be found in the new “Permissions” tab when creating or editing a user:
  - Allow/disallow creating shares. When disallowed the “Upload” button is hidden in the navbar for that user. Navigating directly to the /upload page shows a error page and links to the user’s existing “My Shares” page.
  - Allow/disallow creating reverse share links. When disallowed the “Create” button is hidden on the reverse share page (the modal is not accessible anywhere else).
  - Limit the number of active shares a user can have (minimum of 1). When a user would exceed their limit (after attempting to create a share), the user gets a toast error stating they’ve reached their limit.
  - Limit the number of active reverse shares a user can have (minimum of 1). Disallow flow is same as above.

## How has it been tested?
- Created a new user account via the “Create” button on the “User Management” page. Unticked all the permissions in the perms tab. Verified after creation (and refreshing) the user still has no perms.
- Created a new user account via regular sign up for testing.
  - Tested share limit via: 
    - Share limit to 1. Created 1 share successfully, then was shown an error when trying to create the second share. 
    - Disabled share limit. Created 2 shares. Set share limit to 1. Both shares still accessible however the user receives same error toast when trying to create another.
  - Tested reverse share limit with the same steps as above, same behavior.
  - Tested disallowing regular shares:
    - After refresh: the “Upload” button in the nav bar dissapears
    - Navigating directly to the /upload endpoint shows an error page.
  - Tested disallowing reverse shares:
    - The reverse shares page then just shows existing rev shares, create button is gone.   

## Screenshots
New tabbed layout in edit user modal:
<img width="1002" height="1116" alt="image" src="https://github.com/user-attachments/assets/5f66523c-2f1e-416b-bc83-63919be40c94" />


New permissions tab:
<img width="975" height="1242" alt="image" src="https://github.com/user-attachments/assets/6252f4a5-9f10-4865-8f93-c0b2a947a317" />



Error when user directly navigates to /upload when they’re disallowed
<img width="1916" height="1218" alt="image" src="https://github.com/user-attachments/assets/8b343a0d-33da-4187-9b1c-fc94e904fd8d" />


Closes #120 
